### PR TITLE
Adhere to typescript_auto_format setting for typescript_paste_and_format.

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -183,6 +183,7 @@
         "keys": [ "super+v" ],
         "command": "typescript_paste_and_format",
         "context": [
+            { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
             { "key": "selector", "operator": "equal", "operand": "source.ts" }
         ]
     }


### PR DESCRIPTION
One leftover from the fix to #105.