### PR TITLE
Show signature overloads (and completions) in the Quick Panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-TypeScript.tmLanguage.cache
-FindRefs.hidden-tmLanguage.cache
+*.cache
 .tmpbuf
 .log*
 built/*

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -87,6 +87,20 @@
             { "key": "selector", "operator": "equal", "operand": "source.ts" }
         ]
     },
+    {
+        "keys": [ "ctrl+t", "ctrl+c" ],
+        "command": "typescript_completion_panel",
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "source.ts" }
+        ]
+    },
+    {
+        "keys": [ "ctrl+t", "ctrl+o" ],
+        "command": "typescript_signature_panel",
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "source.ts" }
+        ]
+    },
     // In case when auto match is enabled, only format if not within {}
     {
         "keys": [ "}" ],

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -95,10 +95,24 @@
         ]
     },
     {
+        "keys": [ "?" ],
+        "command": "typescript_completion_panel",
+        "context": [
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\.$" }
+        ]
+    },
+    {
         "keys": [ "ctrl+t", "ctrl+o" ],
         "command": "typescript_signature_panel",
         "context": [
             { "key": "selector", "operator": "equal", "operand": "source.ts" }
+        ]
+    },
+    {
+        "keys": [ "?" ],
+        "command": "typescript_signature_panel",
+        "context": [
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\($" }
         ]
     },
     // In case when auto match is enabled, only format if not within {}

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -88,20 +88,6 @@
         ]
     },
     {
-        "keys": [ "ctrl+t", "ctrl+c" ],
-        "command": "typescript_completion_panel",
-        "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts" }
-        ]
-    },
-    {
-        "keys": [ "?" ],
-        "command": "typescript_completion_panel",
-        "context": [
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\.$" }
-        ]
-    },
-    {
         "keys": [ "ctrl+t", "ctrl+o" ],
         "command": "typescript_signature_panel",
         "context": [
@@ -112,7 +98,8 @@
         "keys": [ "?" ],
         "command": "typescript_signature_panel",
         "context": [
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\($" }
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\($" },
+            { "key": "selector", "operator": "equal", "operand": "source.ts" }
         ]
     },
     // In case when auto match is enabled, only format if not within {}

--- a/TypeScript.py
+++ b/TypeScript.py
@@ -879,6 +879,42 @@ class TypescriptQuickInfo(sublime_plugin.TextCommand):
         return is_typescript(self.view)
 
 
+class TypescriptCompletionPanel(sublime_plugin.TextCommand):
+    def run(self, text):
+        print('TypeScript completion panel triggered')
+        members = [
+            'addEventListener',
+            'anchors',
+            'appendChild',
+            'attributes']
+        self.view.window().show_quick_panel(members, self.on_selected)
+
+    def on_selected(self, index):
+        member = 'addEventListener'
+        self.view.run_command('insert', {'characters': member})
+
+    def is_enabled(self):
+        return is_typescript(self.view)
+
+
+class TypescriptSignaturePanel(sublime_plugin.TextCommand):
+    def run(self, text):
+        print('TypeScript signature panel triggered')
+        eventListenerOverloads = [
+            'addEventListener(type: "pointeenter", listener: (ev: PointerEvent) => any, useCapture?: boolean): void;',
+            'addEventListener(type: "pointerout", listener: (ev: PointerEvent) => any, useCapture?: boolean): void;',
+            'addEventListener(type: "pointerdown", listener: (ev: PointerEvent) => any, useCapture?: boolean): void;',
+            'addEventListener(type: "pointerup", listener: (ev: PointerEvent) => any, useCapture?: boolean): void;']
+        self.view.window().show_quick_panel(eventListenerOverloads, self.on_selected)
+
+    def on_selected(self, index):
+        snippet = '${1:type: "mouseout"}, ${2:listener: (ev: MouseEvent) => any}, ${3:useCapture?: boolean}'
+        self.view.run_command('insert_snippet', {"contents": snippet})
+
+    def is_enabled(self):
+        return is_typescript(self.view)
+
+
 class TypescriptShowDoc(sublime_plugin.TextCommand):
     def run(self, text, infoStr="", docStr=""):
        self.view.insert(text, self.view.sel()[0].begin(), infoStr + "\n\n")
@@ -1464,4 +1500,3 @@ def plugin_unloaded():
         if refInfo:
             refView.settings().set('refinfo', refInfo.asValue())
     cli.service.exit()
-

--- a/TypeScript.sublime-commands
+++ b/TypeScript.sublime-commands
@@ -1,6 +1,8 @@
 [
  { "caption" : "TypeScript: GoToDefinition", "command": "typescript_go_to_definition" },
  { "caption" : "TypeScript: QuickInfoDocumentation", "command": "typescript_quick_info_doc" },
+ { "caption" : "TypeScript: Completions panel", "command": "typescript_completion_panel" },
+ { "caption" : "TypeScript: Overloads panel", "command": "typescript_signature_panel" },
  { "caption" : "TypeScript: SaveTmp", "command": "typescript_save" },
  { "caption" : "TypeScript: FormatSelection", "command": "typescript_format_selection" },
  { "caption" : "TypeScript: FormatDocument", "command": "typescript_format_document" },
@@ -10,4 +12,3 @@
  { "caption" : "TypeScript: FormatLine", "command": "typescript_format_line" },
  { "caption" : "TypeScript: FormatBlock", "command": "typescript_format_brackets" }
 ]
-

--- a/TypeScript.sublime-commands
+++ b/TypeScript.sublime-commands
@@ -1,7 +1,6 @@
 [
  { "caption" : "TypeScript: GoToDefinition", "command": "typescript_go_to_definition" },
  { "caption" : "TypeScript: QuickInfoDocumentation", "command": "typescript_quick_info_doc" },
- { "caption" : "TypeScript: Completions panel", "command": "typescript_completion_panel" },
  { "caption" : "TypeScript: Overloads panel", "command": "typescript_signature_panel" },
  { "caption" : "TypeScript: SaveTmp", "command": "typescript_save" },
  { "caption" : "TypeScript: FormatSelection", "command": "typescript_format_selection" },

--- a/libs/servicedefs.py
+++ b/libs/servicedefs.py
@@ -405,7 +405,71 @@ class CompletionsRequest(FileLocationRequest):
         be the empty string), return the possible completions that
         begin with prefix.
         """
-        super(CompletionsRequest, self).__init__("completions", seq, completionsRequestArgs)
+        super(CompletionsRequest, self).__init__(
+                            "completions", seq, completionsRequestArgs)
+
+
+class SignatureHelpRequestArgs(FileLocationRequestArgs):
+    def __init__(self, file, line, offset, prefix=""):
+        """
+        Arguments for signature help messages
+        ``prefix`` Optional prefix to apply to possible completions.
+        """
+        super(SignatureHelpRequestArgs, self).__init__(file, line, offset)
+        self.prefix = prefix
+
+
+class SignatureHelpRequest(FileLocationRequest):
+    def __init__(self, seq, signatureHelpRequestArgs):
+        """
+        Signature help request; value of command field is "signatureHelp".
+        Given a file location (file, line, offset) and a prefix (which may
+        be the empty string), return the signature help overloads.
+        """
+        super(SignatureHelpRequest, self).__init__(
+                            "signatureHelp", seq, signatureHelpRequestArgs)
+
+
+class SignatureHelpResponse(Response):
+    def __init__(self, body=None, **kwargs):
+        super(SignatureHelpResponse, self).__init__(**kwargs)
+        self.body = SignatureHelpItems(**body) if body else None
+
+
+class SignatureHelpItems:
+    def __init__(self, items, applicableSpan, selectedItemIndex,
+                 argumentIndex, argumentCount, **kwargs):
+        self.items = [SignatureHelpItem(**shi)
+                      for shi in items] if items else None
+        self.applicableSpan = TextSpan(applicableSpan) if applicableSpan else None
+        self.selectedItemIndex = selectedItemIndex
+        self.argumentIndex = argumentIndex
+        self.argumentCount = argumentCount
+
+
+class SignatureHelpItem:
+    def __init__(self, isVariadic, prefixDisplayParts, suffixDisplayParts,
+                 separatorDisplayParts, parameters, documentation):
+        self.isVariadic = isVariadic
+        self.prefixDisplayParts = [SymbolDisplayPart(**pdp) for pdp in prefixDisplayParts] if prefixDisplayParts else None
+        self.suffixDisplayParts = [SymbolDisplayPart(**sdp) for sdp in suffixDisplayParts] if suffixDisplayParts else None
+        self.separatorDisplayParts = [SymbolDisplayPart(**sdp) for sdp in separatorDisplayParts] if separatorDisplayParts else None
+        self.parameters = [SignatureHelpParameter(**shp) for shp in parameters] if parameters else None
+        self.documentation = [SymbolDisplayPart(**doc) for doc in documentation] if documentation else None
+
+
+class SignatureHelpParameter:
+    def __init__(self, name, documentation, displayParts, isOptional):
+        this.name = name
+        this.isOptional = isOptional
+        self.documentation = [SymbolDisplayPart(**doc) for doc in documentation] if documentation else None
+        self.displayParts = [SymbolDisplayPart(**pdp) for pdp in displayParts] if displayParts else None
+
+
+class TextSpan:
+    def __init__(self, start, end):
+        self.start = Location(start)
+        self.end = Location(end)
 
 
 class SymbolDisplayPart:
@@ -433,12 +497,6 @@ class CompletionItem:
         self.kindModifiers = kindModifiers
         self.displayParts = [SymbolDisplayPart(**dp) for dp in displayParts] if displayParts else None
         self.documentation = [SymbolDisplayPart(**dp) for dp in documentation] if documentation else None
-
-
-class CompletionsResponse(Response):
-    def __init__(self, body=None, **kwargs):
-        super(CompletionsResponse, self).__init__(**kwargs)
-        self.body = [CompletionItem(**ci) for ci in body] if body else None
 
 
 class GeterrRequestArgs:

--- a/libs/servicedefs.py
+++ b/libs/servicedefs.py
@@ -441,7 +441,7 @@ class SignatureHelpItems:
                  argumentIndex, argumentCount, **kwargs):
         self.items = [SignatureHelpItem(**shi)
                       for shi in items] if items else None
-        self.applicableSpan = TextSpan(applicableSpan) if applicableSpan else None
+        self.applicableSpan = TextSpan(**applicableSpan) if applicableSpan else None
         self.selectedItemIndex = selectedItemIndex
         self.argumentIndex = argumentIndex
         self.argumentCount = argumentCount
@@ -460,16 +460,16 @@ class SignatureHelpItem:
 
 class SignatureHelpParameter:
     def __init__(self, name, documentation, displayParts, isOptional):
-        this.name = name
-        this.isOptional = isOptional
+        self.name = name
+        self.isOptional = isOptional
         self.documentation = [SymbolDisplayPart(**doc) for doc in documentation] if documentation else None
         self.displayParts = [SymbolDisplayPart(**pdp) for pdp in displayParts] if displayParts else None
 
 
 class TextSpan:
     def __init__(self, start, end):
-        self.start = Location(start)
-        self.end = Location(end)
+        self.start = Location(**start)
+        self.end = Location(**end)
 
 
 class SymbolDisplayPart:

--- a/libs/serviceproxy.py
+++ b/libs/serviceproxy.py
@@ -43,6 +43,15 @@ class ServiceProxy:
             onCompleted(obj)
         self.__comm.sendCmd(onCompletedJson, jsonStr, req.seq)
 
+    def signatureHelp(self, path, location=Location(1, 1), prefix="", onCompleted=None):
+        req = servicedefs.SignatureHelpRequest(self.incrSeq(),
+                                            servicedefs.SignatureHelpRequestArgs(path, location.line, location.offset, prefix))
+        jsonStr = jsonhelpers.encode(req)
+        def onCompletedJson(responseDict):
+            obj = jsonhelpers.fromDict(servicedefs.SignatureHelpResponse, responseDict)
+            onCompleted(obj)
+        self.__comm.sendCmd(onCompletedJson, jsonStr, req.seq)
+
     def definition(self, path, location=Location(1, 1)):
         req = servicedefs.DefinitionRequest(self.incrSeq(), servicedefs.FileLocationRequestArgs(path, location.line, location.offset))
         jsonStr = jsonhelpers.encode(req)


### PR DESCRIPTION
This is a work in progress, just putting it up here for feedback.  See #92 for more details.

Effectively, after you type the opening paren of a function call, if you hit the question mark '?', then a list of overloads will pop up in the quick panel (see below for when cursor was in the jQuery `attr` function on line 10).  If you select one of these, it will populate the arguments as snippets, so you can tab over each param and replace it with the desired args.  (It may look better if the param list is wrapped in parens, and add the return type..., or maybe even repeat the full sig with name as well - thoughts?)

![screen shot 2015-04-04 at 2 32 55 am](https://cloud.githubusercontent.com/assets/993909/6992178/fa654d4c-da72-11e4-8e18-06c10c1de32e.png)


Note I added a similar mechanism for the member completion list too (press '?' after the dot operator) in case people prefer the look and feel of the Quick Panel, but this may not be needed with completions working here anyway.

The completion panel is also available via [ctrl-t, ctrl-c], the the signature overloads panel by [ctrl-t, ctrl-o].

Still need to work on tidying up some scenarios, but happy for feedback before iterating further.