### PR TITLE
Move the trigger of ``format_on_key`` command to ``on_modified``

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -135,57 +135,6 @@
             { "key": "selector", "operator": "equal", "operand": "source.ts" },
             { "key": "is_popup_visible"}
         ]
-    },    // In case when auto match is enabled, only format if not within {}
-    {
-        "keys": [ "}" ],
-        "command": "typescript_format_on_key",
-        "args": { "key": "}" },
-        "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts" },
-            { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-            { "key": "num_selections", "operator": "equal", "operand": 1},
-            { "key": "selection_empty", "operator": "equal", "operand": true },
-
-            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\{$" },
-            { "key": "following_text", "operator": "not_regex_contains", "operand": "^\\}" }
-        ]
-    },
-    // In case when auto match is disabled, format the block regardless
-    {
-        "keys": [ "}" ],
-        "command": "typescript_format_on_key",
-        "args": { "key": "}" },
-        "context": [
-            { "key": "num_selections", "operator": "equal", "operand": 1},
-            { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts" },
-            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": false }
-        ]
-    },
-    {
-        "keys": [ ";" ],
-        "command": "typescript_format_on_key",
-        "args": { "key": ";" },
-        "context": [
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts" }
-        ]
-    },
-    {
-        "keys": [ "enter" ],
-        "command": "typescript_format_on_key",
-        "args": { "key": "\n" },
-        "context": [
-            { "key": "setting.typescript_auto_indent", "operator": "equal", "operand": true },
-            { "key": "auto_complete_visible", "operator": "equal", "operand": false },
-            { "key": "selector", "operator": "not_equal", "operand": "meta.scope.between-tag-pair" },
-            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "num_selections", "operator": "equal", "operand": 1},
-            { "key": "selector", "operator": "equal", "operand": "source.ts" }
-        ]
     },
     {
         "keys": [ "enter" ],

--- a/typescript/commands/format.py
+++ b/typescript/commands/format.py
@@ -11,11 +11,6 @@ class TypescriptFormatOnKey(TypeScriptBaseTextCommand):
         if 0 == len(key):
             return
         check_update_view(self.view)
-        loc = self.view.sel()[0].begin()
-
-        if insert_key:
-            active_view().run_command('hide_auto_complete')
-            insert_text(self.view, text, loc, key)
 
         format_response = cli.service.format_on_key(self.view.file_name(), get_location_from_view(self.view), key)
         if format_response["success"]:

--- a/typescript/libs/__init__.py
+++ b/typescript/libs/__init__.py
@@ -5,7 +5,6 @@ from .editor_client import cli, EditorClient
 from .popup_manager import get_popup_manager
 from .logger import log
 from . import logger
-
 __all__ = [
     'cli',
     'EditorClient',

--- a/typescript/libs/editor_client.py
+++ b/typescript/libs/editor_client.py
@@ -34,6 +34,9 @@ class EditorClient:
         self.tab_size = 4
         self.indent_size = 4
         self.translate_tab_to_spaces = False
+        self.ts_auto_format_enabled = True
+        self.ts_auto_indent_enabled = True
+        self.auto_match_enabled = True
 
     def initialize(self):
         """
@@ -55,7 +58,14 @@ class EditorClient:
         self.service = ServiceProxy(self.node_client)
 
         # load formatting settings and set callbacks for setting changes
-        for setting_name in ['tab_size', 'indent_size', 'translate_tabs_to_spaces']:
+        for setting_name in [
+            'tab_size',
+            'indent_size',
+            'translate_tabs_to_spaces',
+            'typescript_auto_format',
+            'typescript_auto_indent',
+            'auto_match_enabled'
+        ]:
             settings.add_on_change(setting_name, self.load_format_settings)
         self.load_format_settings()
 
@@ -66,6 +76,9 @@ class EditorClient:
         self.tab_size = settings.get('tab_size', 4)
         self.indent_size = settings.get('indent_size', 4)
         self.translate_tab_to_spaces = settings.get('translate_tabs_to_spaces', False)
+        self.ts_auto_format_enabled = settings.get("typescript_auto_format")
+        self.ts_auto_indent_enabled = settings.get("typescript_auto_indent")
+        self.auto_match_enabled = settings.get("auto_match_enabled")
         self.set_features()
 
     def set_features(self):

--- a/typescript/libs/global_vars.py
+++ b/typescript/libs/global_vars.py
@@ -4,22 +4,33 @@ import logging
 import sublime
 from os.path import dirname
 
+# determine if the host is sublime text 2
+IS_ST2 = int(sublime.version()) < 3000
 
 # Get the directory path to this file;
-# Note: MODULE_DIR, PLUGIN_DIR and PLUGIN_NAME only works correctly when:
-# 1. Using sublime 3
-# 2. Using sublime 2, and the plugin folder is not a symbol link
-# On sublime 2 with the plugin folder being a symbol link, the PLUGIN_FOLDER will points
-# to the linked real path instead, and the PLUGIN_NAME will be wrong too.
-MODULE_DIR = dirname(dirname(os.path.abspath(__file__)))
-PLUGIN_DIR = dirname(MODULE_DIR)
+# Note: there are several ways this plugin can be installed
+# 1. from the package control -> the absolute path of __file__ is real and contains plugin name
+# 2. git clone directly to the sublime packages folder -> the absolute path of __file__ is real and contains plugin name
+# 3. git clone to somewhere else, and link to the sublime packages folder -> the absolute path is real in Sublime 3,
+# but is somewhere else in Sublime 2;and therefore in Sublime 2 there is no direct way to obtain the plugin name
+if not IS_ST2:
+    PLUGIN_DIR = dirname(dirname(dirname(os.path.abspath(__file__))))
+else:
+    _sublime_packages_dir = sublime.packages_path()
+    _cur_file_abspath = os.path.abspath(__file__)
+    if _sublime_packages_dir not in _cur_file_abspath:
+        # The plugin is installed as a link
+        for p in os.listdir(_sublime_packages_dir):
+            link_path = _sublime_packages_dir + os.sep + p
+            if os.path.realpath(link_path) in _cur_file_abspath:
+                PLUGIN_DIR = link_path
+                break
+    else:
+        PLUGIN_DIR = dirname(dirname(dirname(os.path.abspath(__file__))))
 PLUGIN_NAME = os.path.basename(PLUGIN_DIR)
 
 # only Sublime Text 3 build after 3072 support tooltip
 TOOLTIP_SUPPORT = int(sublime.version()) >= 3072
-
-# determine if the host is sublime text 2
-IS_ST2 = int(sublime.version()) < 3000
 
 # detect if quick info is available for symbol
 SUBLIME_WORD_MASK = 515

--- a/typescript/libs/global_vars.py
+++ b/typescript/libs/global_vars.py
@@ -1,9 +1,8 @@
 import os
 import re
-
+import logging
 import sublime
 from os.path import dirname
-from .logger import *
 
 
 # get the directory path to this file; 
@@ -23,7 +22,7 @@ SUBLIME_WORD_MASK = 515
 
 # set logging levels
 LOG_FILE_LEVEL = logging.WARN
-LOG_CONSOLE_LEVEL = logging.WARN
+LOG_CONSOLE_LEVEL = logging.DEBUG
 
 NON_BLANK_LINE_PATTERN = re.compile("[\S]+")
 VALID_COMPLETION_ID_PATTERN = re.compile("[a-zA-Z_$\.][\w$\.]*\Z")

--- a/typescript/libs/global_vars.py
+++ b/typescript/libs/global_vars.py
@@ -22,7 +22,7 @@ SUBLIME_WORD_MASK = 515
 
 # set logging levels
 LOG_FILE_LEVEL = logging.WARN
-LOG_CONSOLE_LEVEL = logging.DEBUG
+LOG_CONSOLE_LEVEL = logging.WARN
 
 NON_BLANK_LINE_PATTERN = re.compile("[\S]+")
 VALID_COMPLETION_ID_PATTERN = re.compile("[a-zA-Z_$\.][\w$\.]*\Z")

--- a/typescript/listeners/format.py
+++ b/typescript/listeners/format.py
@@ -1,4 +1,6 @@
 from .event_hub import EventHub
+from ..libs.view_helpers import *
+from ..libs.logger import log
 
 
 class FormatEventListener:
@@ -11,5 +13,38 @@ class FormatEventListener:
              "typescript_paste_and_format"]:
             print("handled changes for " + command_name)
 
+    def on_modified_with_info(self, view, info):
+        log.debug("Format on key")
+        _settings = sublime.load_settings('Preferences.sublime-settings')
+        ts_auto_format_enabled = _settings.get("typescript_auto_format")
+        ts_auto_indent_enabled = _settings.get("typescript_auto_indent")
+        auto_match_enabled = _settings.get("auto_match_enabled")
+
+        if (
+            is_typescript(view) and
+            ts_auto_format_enabled and
+            len(info.prev_sel) == 1 and
+            info.prev_sel[0].empty()
+        ):
+            last_command, args, repeat_times = view.command_history(0)
+            log.debug("last_command:{0}, args:{1}".format(last_command, args))
+            if last_command == "insert":
+                pos = info.prev_sel[0].begin()
+                if ";" in args["characters"]:
+                    view.run_command("typescript_format_on_key", {"key": ";"})
+                elif "}" in args["characters"]:
+                    if auto_match_enabled:
+                        prev_char = view.substr(pos - 1)
+                        post_char = view.substr(pos + 1)
+                        log.debug("prev_char: {0}, post_char: {1}".format(prev_char, post_char))
+                        if prev_char != "{" and post_char != "}":
+                            view.run_command("typescript_format_on_key", {"key": "}"})
+                    else:
+                        view.run_command("typescript_format_on_key", {"key": "}"})
+                elif "\n" in args["characters"]:
+                    if ts_auto_indent_enabled and view.score_selector(pos, "meta.scope.between-tag-pair") > 0:
+                        view.run_command("typescript_format_on_key", {"key": "\n"})
+
 listener = FormatEventListener()
 EventHub.subscribe("on_post_text_command_with_info", listener.on_post_text_command_with_info)
+EventHub.subscribe("on_modified_with_info", listener.on_modified_with_info)

--- a/typescript/listeners/format.py
+++ b/typescript/listeners/format.py
@@ -1,7 +1,7 @@
 from .event_hub import EventHub
 from ..libs.view_helpers import *
 from ..libs.logger import log
-
+from ..libs import cli
 
 class FormatEventListener:
     def on_post_text_command_with_info(self, view, command_name, args, info):
@@ -15,14 +15,11 @@ class FormatEventListener:
 
     def on_modified_with_info(self, view, info):
         log.debug("Format on key")
-        _settings = sublime.load_settings('Preferences.sublime-settings')
-        ts_auto_format_enabled = _settings.get("typescript_auto_format")
-        ts_auto_indent_enabled = _settings.get("typescript_auto_indent")
-        auto_match_enabled = _settings.get("auto_match_enabled")
 
         if (
             is_typescript(view) and
-            ts_auto_format_enabled and
+            cli.ts_auto_format_enabled and
+            info.prev_sel and
             len(info.prev_sel) == 1 and
             info.prev_sel[0].empty()
         ):
@@ -32,8 +29,8 @@ class FormatEventListener:
                 pos = info.prev_sel[0].begin()
                 if ";" in args["characters"]:
                     view.run_command("typescript_format_on_key", {"key": ";"})
-                elif "}" in args["characters"]:
-                    if auto_match_enabled:
+                if "}" in args["characters"]:
+                    if cli.auto_match_enabled:
                         prev_char = view.substr(pos - 1)
                         post_char = view.substr(pos + 1)
                         log.debug("prev_char: {0}, post_char: {1}".format(prev_char, post_char))
@@ -41,8 +38,8 @@ class FormatEventListener:
                             view.run_command("typescript_format_on_key", {"key": "}"})
                     else:
                         view.run_command("typescript_format_on_key", {"key": "}"})
-                elif "\n" in args["characters"]:
-                    if ts_auto_indent_enabled and view.score_selector(pos, "meta.scope.between-tag-pair") > 0:
+                if "\n" in args["characters"]:
+                    if cli.ts_auto_indent_enabled and view.score_selector(pos, "meta.scope.between-tag-pair") > 0:
                         view.run_command("typescript_format_on_key", {"key": "\n"})
 
 listener = FormatEventListener()


### PR DESCRIPTION
Our current trigger for the ``format_on_key`` command is to intercept the keystroke before it appears in the buffer, which has caused many problems:
1. The typed characters wouldn't show up if the command failed;
2. For multiple cursors, only the first cursor would insert test because we choose to do the insertion by ourselves;
3. Lag before the characters show up if the formatting takes too long.

Therefore it might be better to move the trigger for ``format_on_key`` to the ``on_modified`` event listener, because the listener is called **after** the characters are inserted. 

Fix issue: #194 