### PR TITLE
Fix confusing snippet triggers

### DIFF
--- a/snippets/get-()-{}.sublime-snippet
+++ b/snippets/get-()-{}.sublime-snippet
@@ -4,7 +4,7 @@ public get ${1:value}() : ${2:string} {
 	${3:return }
 }
 ]]></content>
-	<tabTrigger>get</tabTrigger>
+	<tabTrigger>getter</tabTrigger>
 	<scope>source.ts</scope>
     <description>get-property …</description>
 </snippet>

--- a/snippets/log.sublime-snippet
+++ b/snippets/log.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[console.log($1);
 $0]]></content>
-    <tabTrigger>log</tabTrigger>
+    <tabTrigger>clog</tabTrigger>
     <scope>source.ts</scope>
     <description>console log</description>
 </snippet>

--- a/snippets/set-()-{}.sublime-snippet
+++ b/snippets/set-()-{}.sublime-snippet
@@ -4,7 +4,7 @@ public set ${1:value}(v : ${2:string}) {
 	this.${3:_value} = v;
 }
 ]]></content>
-	<tabTrigger>set</tabTrigger>
+	<tabTrigger>setter</tabTrigger>
 	<scope>source.ts</scope>
     <description>set-property …</description>
 </snippet>

--- a/snippets/setTimeout.sublime-snippet
+++ b/snippets/setTimeout.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[setTimeout(() => {$0}${2:}, ${1:500});]]></content>
-    <tabTrigger>timeout</tabTrigger>
+    <tabTrigger>tout</tabTrigger>
     <scope>source.ts</scope>
     <description>setTimeout function</description>
 </snippet>


### PR DESCRIPTION
Some of the snippet triggers have the same name with common TS method/property names; it can lead to confusing behavior when they show up together in the completion list. For example, when typing ``console.`` both the snippet ``log`` and the member ``log`` would show up, but they will insert different content once committed. 

Fix #211 and #201 