### PR TITLE
Fix the issue that tooltip doesn't have proper style in Windows 64 version ST 3

### DIFF
--- a/typescript/libs/popup_manager.py
+++ b/typescript/libs/popup_manager.py
@@ -1,3 +1,5 @@
+import re
+
 from string import Template
 
 from .logger import log
@@ -236,6 +238,8 @@ def get_popup_manager():
 
             log.info('Popup resource path: {0}'.format(rel_path))
             popup_text = sublime.load_resource(rel_path)
+            re_remove = re.compile("[\n\t\r]")
+            popup_text = re_remove.sub("", popup_text)
             log.info('Loaded tooltip template from {0}'.format(rel_path))
 
             PopupManager.html_template = Template(popup_text)


### PR DESCRIPTION
The reason the styles cannot be applied seems to be the CR line endings in the html string. Proper style is working after removing the line endings.

Fix #219 