### PR TITLE
Extend scope of meta.field.declaration.ts to next lines by removing \n from the end mark

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -143,7 +143,7 @@ repository:
     beginCaptures:
       '1': { name: variable.ts }
       '2': { name: keyword.operator.ts }
-    end: '(?=\}|;|,)|(?<=\})'
+    end: '(?=\}|;|,|\n)|(?<=\})'
     patterns:
     - include: '#expression'
 

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -143,7 +143,7 @@ repository:
     beginCaptures:
       '1': { name: variable.ts }
       '2': { name: keyword.operator.ts }
-    end: '(?=\}|;|,|\n)|(?<=\})'
+    end: '(?=\}|;|,)|(?<=\})'
     patterns:
     - include: '#expression'
 

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -395,7 +395,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?=\}|;|,)|(?&lt;=\})</string>
+			<string>(?=\}|;|,|\n)|(?&lt;=\})</string>
 			<key>name</key>
 			<string>meta.field.declaration.ts</string>
 			<key>patterns</key>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -395,7 +395,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?=\}|;|,|\n)|(?&lt;=\})</string>
+			<string>(?=\}|;|,)|(?&lt;=\})</string>
 			<key>name</key>
 			<string>meta.field.declaration.ts</string>
 			<key>patterns</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -148,7 +148,7 @@ repository:
     beginCaptures:
       '1': { name: variable.tsx }
       '2': { name: keyword.operator.tsx }
-    end: '(?=\}|;|,|\n)|(?<=\})'
+    end: '(?=\}|;|,)|(?<=\})'
     patterns:
     - include: '#expression'
 

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -363,7 +363,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?=\}|;|,|\n)|(?&lt;=\})</string>
+			<string>(?=\}|;|,)|(?&lt;=\})</string>
 			<key>name</key>
 			<string>meta.field.declaration.tsx</string>
 			<key>patterns</key>


### PR DESCRIPTION
This should fix issue: [228](https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/228)

Before:
![image](https://cloud.githubusercontent.com/assets/1707813/8217210/dd6166f0-14f0-11e5-851f-73ad519e4efa.png)

After:
![image](https://cloud.githubusercontent.com/assets/1707813/8217217/e3d76be2-14f0-11e5-8712-59ff78291305.png)