### PR TITLE
Fix issue 245.

### DIFF
--- a/typescript/libs/view_helpers.py
+++ b/typescript/libs/view_helpers.py
@@ -40,7 +40,7 @@ def get_info(view):
         cli.initialize()
 
     info = None
-    if view.file_name() is not None:
+    if view is not None and view.file_name() is not None:
         file_name = view.file_name()
         if is_typescript(view):
             info = _file_map.get(file_name)


### PR DESCRIPTION
`view` can be `null` when using multiple column layout; add a null guard to avoid NoneType exception.