### PR TITLE
Show error span at the last non-whitespace character of the file if the error is at EOF.

### DIFF
--- a/typescript/libs/text_helpers.py
+++ b/typescript/libs/text_helpers.py
@@ -126,3 +126,4 @@ def build_replace_regions(empty_regions_a, empty_regions_b):
     for i in range(len(empty_regions_a)):
         rr.append(sublime.Region(empty_regions_a[i].begin(), empty_regions_b[i].begin()))
     return rr
+    

--- a/typescript/libs/view_helpers.py
+++ b/typescript/libs/view_helpers.py
@@ -316,3 +316,19 @@ def change_count(view):
             return info.modify_count
         else:
             return view.change_count()
+
+def last_non_whitespace_position(view):
+    """
+    Returns the position of the last non-whitespace character of <view>.
+    Returns -1 if <view> contains no non-whitespace character.
+    """
+    pos = view.size() - 1
+    while pos >= 0 and view.substr(pos).isspace():
+        pos -= 1
+    return pos
+
+def last_character_region(view):
+    """Returns the last non whitespace character under <sublime.Region> format"""
+    pos = last_non_whitespace_position(view)
+    return sublime.Region(pos, pos + 1)
+

--- a/typescript/libs/view_helpers.py
+++ b/typescript/libs/view_helpers.py
@@ -320,15 +320,15 @@ def change_count(view):
 def last_non_whitespace_position(view):
     """
     Returns the position of the last non-whitespace character of <view>.
-    Returns -1 if <view> contains no non-whitespace character.
+    Returns -1 if <view> only contains non-whitespace characters.
     """
     pos = view.size() - 1
     while pos >= 0 and view.substr(pos).isspace():
         pos -= 1
     return pos
 
-def last_character_region(view):
-    """Returns the last non whitespace character under <sublime.Region> format"""
+def last_visible_character_region(view):
+    """Returns a <sublime.Region> for the last non whitespace character"""
     pos = last_non_whitespace_position(view)
     return sublime.Region(pos, pos + 1)
 

--- a/typescript/listeners/idle.py
+++ b/typescript/listeners/idle.py
@@ -89,16 +89,22 @@ class IdleListener:
                         start = view.text_point(line, offset)
                         end = view.text_point(end_line, end_offset)
                         if end <= view.size():
-                            region = sublime.Region(start, end)
+                            if start == view.size() and start == end:
+                                region = last_character_region(view)
+                            else:
+                                region = sublime.Region(start, end)
                             error_regions.append(region)
                             client_info.errors[region_key].append((region, diagno["text"]))
                 info.has_errors = cli.has_errors(filename)
                 self.update_status(view, info)
                 if IS_ST2:
-                    view.add_regions(region_key, error_regions, "keyword", "", sublime.DRAW_OUTLINED)
+                    view.add_regions(region_key, error_regions, "keyword", "", 
+                                     sublime.DRAW_OUTLINED)
                 else:
                     view.add_regions(region_key, error_regions, "keyword", "",
-                                     sublime.DRAW_NO_FILL + sublime.DRAW_NO_OUTLINE + sublime.DRAW_SQUIGGLY_UNDERLINE)
+                                     sublime.DRAW_NO_FILL +
+                                     sublime.DRAW_NO_OUTLINE +
+                                     sublime.DRAW_SQUIGGLY_UNDERLINE)
 
     def dispatch_event(self, ev):
         event_type = ev["event"]

--- a/typescript/listeners/idle.py
+++ b/typescript/listeners/idle.py
@@ -69,42 +69,59 @@ class IdleListener:
         filename = diagno_event_body["file"]
         if os.name == 'nt' and filename:
             filename = filename.replace('/', '\\')
-        diagnos = diagno_event_body["diagnostics"]
+
         info = get_info_with_filename(filename)
-        if info:
-            view = info.view
-            if not info.change_count_when_last_err_req_sent == change_count(view):
-                log.debug("The error info is outdated")
-                self.set_on_idle_timer(200)
-            else:
-                region_key = 'syntacticDiag' if syntactic else 'semanticDiag'
-                view.erase_regions(region_key)
-                client_info = cli.get_or_add_file(filename)
-                client_info.errors[region_key] = []
-                error_regions = []
-                if diagnos:
-                    for diagno in diagnos:
-                        line, offset = extract_line_offset(diagno["start"])
-                        end_line, end_offset = extract_line_offset(diagno["end"])
-                        start = view.text_point(line, offset)
-                        end = view.text_point(end_line, end_offset)
-                        if end <= view.size():
-                            if start == view.size() and start == end:
-                                region = last_character_region(view)
-                            else:
-                                region = sublime.Region(start, end)
-                            error_regions.append(region)
-                            client_info.errors[region_key].append((region, diagno["text"]))
-                info.has_errors = cli.has_errors(filename)
-                self.update_status(view, info)
-                if IS_ST2:
-                    view.add_regions(region_key, error_regions, "keyword", "", 
-                                     sublime.DRAW_OUTLINED)
-                else:
-                    view.add_regions(region_key, error_regions, "keyword", "",
-                                     sublime.DRAW_NO_FILL +
-                                     sublime.DRAW_NO_OUTLINE +
-                                     sublime.DRAW_SQUIGGLY_UNDERLINE)
+        if not info:
+            return
+
+        view = info.view
+        if not info.change_count_when_last_err_req_sent == change_count(view):
+            log.debug("The error info is outdated")
+            self.set_on_idle_timer(200)
+            return
+
+        region_key = 'syntacticDiag' if syntactic else 'semanticDiag'
+        view.erase_regions(region_key)
+
+        client_info = cli.get_or_add_file(filename)
+        client_info.errors[region_key] = []
+        error_regions = []
+
+        diagnos = diagno_event_body["diagnostics"]
+        if diagnos:
+            for diagno in diagnos:
+                start_line, start_offset = extract_line_offset(diagno["start"])
+                start = view.text_point(start_line, start_offset)
+
+                end_line, end_offset = extract_line_offset(diagno["end"])
+                end = view.text_point(end_line, end_offset)
+
+                if end <= view.size():
+                    # Creates a <sublime.Region> from <start> to <end> to
+                    # highlight the error. If the region coincides with the
+                    # EOF character, use the region of the last visible
+                    # character instead so user can still see the highlight.
+                    if start == view.size() and start == end:
+                        region = last_visible_character_region(view)
+                    else:
+                        region = sublime.Region(start, end)
+
+                    client_info.errors[region_key].append((region, diagno["text"]))
+                    error_regions.append(region)
+
+        # Update status bar with error information
+        info.has_errors = cli.has_errors(filename)
+        self.update_status(view, info)
+
+        # Highlight error regions in view
+        if IS_ST2:
+            view.add_regions(region_key, error_regions, "keyword", "",
+                             sublime.DRAW_OUTLINED)
+        else:
+            view.add_regions(region_key, error_regions, "keyword", "",
+                             sublime.DRAW_NO_FILL +
+                             sublime.DRAW_NO_OUTLINE +
+                             sublime.DRAW_SQUIGGLY_UNDERLINE)
 
     def dispatch_event(self, ev):
         event_type = ev["event"]


### PR DESCRIPTION
This fixes https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/44.