### PR TITLE
Remove key binding: enter -> commit_completion.

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -145,13 +145,6 @@
     },
     {
         "keys": [ "enter" ],
-        "command": "commit_completion",
-        "context": [
-            { "key": "auto_complete_visible", "operator": "equal", "operand": true }
-        ]
-    },
-    {
-        "keys": [ "enter" ],
         "command": "typescript_auto_indent_on_enter_between_curly_brackets",
         "context": [
             { "key": "setting.typescript_auto_indent", "operator": "equal", "operand": true },


### PR DESCRIPTION
Two reasons to remove this:

1. This is redundant because enter triggers `commit_completion` command by default.
2. The `"auto_complete_commit_on_tab": true` setting won't work if this key binding presents. Issue https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/264.