### PR TITLE
"Function" keyword should be followed by \b.

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -174,7 +174,7 @@ repository:
       
   function-declaration:
     name: meta.function.ts
-    begin: \b(?:(export)\s+)?(function)(?:\s+([a-zA-Z_$][\w$]*))?\s*
+    begin: \b(?:(export)\s+)?(function\b)(?:\s+([a-zA-Z_$][\w$]*))?\s*
     beginCaptures:
       '1': { name: storage.modifier.ts }
       '2': { name: storage.type.function.ts }
@@ -190,7 +190,7 @@ repository:
 
   function-overload-declaration:
     name: meta.function.overload.ts
-    match: \b(?:(export)\s+)?(function)(?:\s+([a-zA-Z_$][\w$]*))?\s*
+    match: \b(?:(export)\s+)?(function\b)(?:\s+([a-zA-Z_$][\w$]*))?\s*
     captures:
       '1': { name: storage.modifier.ts }
       '2': { name: storage.type.function.ts }

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -445,7 +445,7 @@
 		<key>function-declaration</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(?:(export)\s+)?(function)(?:\s+([a-zA-Z_$][\w$]*))?\s*</string>
+			<string>\b(?:(export)\s+)?(function\b)(?:\s+([a-zA-Z_$][\w$]*))?\s*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -517,7 +517,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(?:(export)\s+)?(function)(?:\s+([a-zA-Z_$][\w$]*))?\s*</string>
+			<string>\b(?:(export)\s+)?(function\b)(?:\s+([a-zA-Z_$][\w$]*))?\s*</string>
 			<key>name</key>
 			<string>meta.function.overload.ts</string>
 		</dict>


### PR DESCRIPTION
Make sure what comes after `function` is not a word character. 
This fixes https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/288.