### PR TITLE
Read formatting settings from TypeScript.sublime-settings.

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -1,3 +1,2 @@
 {
-    "typescript_auto_format": true
 }

--- a/typescript/libs/node_client.py
+++ b/typescript/libs/node_client.py
@@ -234,8 +234,6 @@ class ServerClient(NodeCommClient):
         The script file to run is passed to the constructor.
         """
         super(ServerClient, self).__init__(script_path)
-        print("test")
-        print(self.server_proc)
 
         # start node process
         pref_settings = sublime.load_settings('Preferences.sublime-settings')

--- a/typescript/libs/view_helpers.py
+++ b/typescript/libs/view_helpers.py
@@ -156,11 +156,11 @@ def reconfig_file(view):
     view_settings = view.settings()
     tab_size = view_settings.get('tab_size', 4)
     indent_size = view_settings.get('indent_size', tab_size)
-    translate_tab_to_spaces = view_settings.get('translate_tabs_to_spaces', True)
+    translate_tabs_to_spaces = view_settings.get('translate_tabs_to_spaces', True)
     format_options = {
         "tabSize": tab_size,
         "indentSize": indent_size,
-        "convertTabsToSpaces": translate_tab_to_spaces
+        "convertTabsToSpaces": translate_tabs_to_spaces
     }
     cli.service.configure(host_info, view.file_name(), format_options)
 


### PR DESCRIPTION
Enable getting TypeScript formatting settings e.g. `tab_size`, `indent_size`, `translate_tabs_to_spaces`, etc from syntax setting file (`TypeScript.sublime-settings`). This is useful when user wants to have separate tab/indentation settings for `.ts` file.

Related to https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/301.
