### PR TITLE
Mention build version for signature popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Screenshots
 - Project error list
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/errorlist.gif)
 
-- Signature popup
+- Signature popup (Requires [Sublime Text 3](http://www.sublimetext.com/3) build >= 3070)
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/signature.gif)
 
 - Navigate to symbol


### PR DESCRIPTION
Re: https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/279#issuecomment-124083731

Again, the reason for this change is that it's kind of tough to know what to search the text for, but it's easier to see visually what feature the signature popup is. So if you're like me, and you come here wondering why the completion/intellisense/popup/tooltip/type info/etc isn't working, you don't have to spend 20 minutes trying to figure out what it was named.

Hopefully that reason makes sense. If the wording of the change should be different, let me know.