### PR TITLE
Colorize string at certain syntactically incorrect positions.

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -18,6 +18,8 @@ repository:
     end: '(?=$|[;=\}\{])|(?<=\})'
     patterns:
     - include: '#type-annotation'
+    - include: '#string'
+    - include: '#comment'
 
   control-statement:
     name: keyword.control.ts
@@ -90,6 +92,7 @@ repository:
     endCaptures:
       '0': { name: meta.brace.curly.ts }
     patterns:
+    - include: "#string"
     - include: '#comment'
     - include: '#field-declaration'
     - include: '#method-declaration'

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -824,6 +824,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#comment</string>
 				</dict>
 				<dict>
@@ -1590,6 +1594,14 @@
 				<dict>
 					<key>include</key>
 					<string>#type-annotation</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
 				</dict>
 			</array>
 		</dict>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -23,6 +23,8 @@ repository:
     end: '(?=$|[;=\}\{])|(?<=\})'
     patterns:
     - include: '#type-annotation'
+    - include: '#string'
+    - include: '#comment'
 
   control-statement:
     name: keyword.control.tsx
@@ -95,6 +97,7 @@ repository:
     endCaptures:
       '0': { name: meta.brace.curly.tsx }
     patterns:
+    - include: "#string"
     - include: '#comment'
     - include: '#field-declaration'
     - include: '#method-declaration'

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1190,6 +1190,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#comment</string>
 				</dict>
 				<dict>
@@ -1956,6 +1960,14 @@
 				<dict>
 					<key>include</key>
 					<string>#type-annotation</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
This fixes https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/227.

Before:
![image](https://cloud.githubusercontent.com/assets/1707813/8857741/7a52fbf6-3128-11e5-8b21-5911c2e40b5a.png)

After:
![image](https://cloud.githubusercontent.com/assets/1707813/8857754/8102c080-3128-11e5-85de-45bac22ecc87.png)
