### PR TITLE
Colorize string and comment between type and initializer.

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -241,6 +241,8 @@ repository:
     end: (?=$|[,);\}\]]|//)|(?==[^>])|(?<=[\}>\]\)]|[a-zA-Z_$])\s*(?=\{)
     patterns:
     - include: '#type'
+    - include: '#string'
+    - include: '#comment'
 
   type:
     name: meta.type.ts

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1302,6 +1302,14 @@
 					<key>include</key>
 					<string>#type</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
 			</array>
 		</dict>
 		<key>type-declaration</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -246,6 +246,8 @@ repository:
     end: (?=$|[,);\}\]]|//)|(?==[^>])|(?<=[\}>\]\)]|[a-zA-Z_$])\s*(?=\{)
     patterns:
     - include: '#type'
+    - include: '#string'
+    - include: '#comment'
 
   type:
     name: meta.type.tsx

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1668,6 +1668,14 @@
 					<key>include</key>
 					<string>#type</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
 			</array>
 		</dict>
 		<key>type-declaration</key>


### PR DESCRIPTION
This fixes https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/275.

Before:
![image](https://cloud.githubusercontent.com/assets/1707813/8858467/73590148-312c-11e5-964d-e4aca493c87e.png)

After:
![image](https://cloud.githubusercontent.com/assets/1707813/8858455/6443bb9e-312c-11e5-98fd-288f7772e631.png)
