### PR TITLE
Map `Ctrl +V` to `typescript_past_and_format` command on Windows and Linux.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,0 +1,10 @@
+[
+    {
+        "keys": [ "ctrl+v" ],
+        "command": "typescript_paste_and_format",
+        "context": [
+            { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
+            { "key": "selector", "operator": "equal", "operand": "source.ts" }
+        ]
+    }
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,10 @@
+[
+    {
+        "keys": [ "super+v" ],
+        "command": "typescript_paste_and_format",
+        "context": [
+            { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
+            { "key": "selector", "operator": "equal", "operand": "source.ts" }
+        ]
+    }
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,0 +1,10 @@
+[
+    {
+        "keys": [ "ctrl+v" ],
+        "command": "typescript_paste_and_format",
+        "context": [
+            { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
+            { "key": "selector", "operator": "equal", "operand": "source.ts" }
+        ]
+    }
+]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -175,13 +175,5 @@
         "context": [
             { "key": "selector", "operator": "equal", "operand": "source.ts" }
         ]
-    },
-    {
-        "keys": [ "super+v" ],
-        "command": "typescript_paste_and_format",
-        "context": [
-            { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts" }
-        ]
     }
 ]


### PR DESCRIPTION
This fixes https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/310.