### PR TITLE
Prevent unnecessary calls to service.configure

### DIFF
--- a/typescript/libs/view_helpers.py
+++ b/typescript/libs/view_helpers.py
@@ -151,6 +151,11 @@ def open_file_on_worker(view):
     cli.service.open_on_worker(view.file_name())
 
 def reconfig_file(view):
+    """Reconfigure indentation settings for the current view
+
+    Returns True if the settings were configured in the TS service
+    Returns False if the settings did not need to be configured
+    """
     host_info = "Sublime Text version " + str(sublime.version())
     # Preferences Settings
     view_settings = view.settings()


### PR DESCRIPTION
The [Sublime API is somewhat unclear](https://www.sublimetext.com/docs/3/api_reference.html#sublime.Settings), but the `on_change` argument for `Settings.add_on_change` will be called whenever *any* setting changes. The `key` argument is simply a way of referring to the callback in a subsequent call to `Settings.clear_on_change`. This plugin is incorrectly assuming that `key` is the setting name will trigger the supplied callback.

Two changes are included here:
- Only register on_change handler once, since it will be triggered on every setting change
- Check previous format options against current values to detect a change; only call `configure` if one of the values has actually changed

I chose to store the previous values in the view settings because that seems to be the only persistent store for a view. If there is a better way to do this, please let me know.

Fixes #187.

