### PR TITLE
On Linux/MacOS, command passed to subprocess.check_output should be a string rather than a list

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,14 +145,14 @@ def _is_executable(path):
     return os.path.isfile(path) and os.access(path, os.X_OK)
 
 def _get_npm_tsc_version():
-    if os.name != 'nt' and _is_executable("/usr/local/bin/tsc"):
-        cmd = ["/usr/local/bin/tsc", "-v"]
+    if os.name != 'nt' and _is_executable("/usr/local/bin/tsc"): # Default location on MacOS
+        cmd = [get_node_path(), "/usr/local/bin/tsc", "-v"]
     else:
         cmd = ["tsc", "-v"]
     return _execute_cmd_and_parse_version_from_output(cmd)
 
 def _execute_cmd_and_parse_version_from_output(cmd):
-    if os.name != 'nt':
+    if os.name != 'nt': # Linux/MacOS
         cmd = "'" + "' '".join(cmd) + "'"
     output = subprocess.check_output(cmd, shell=True).decode('UTF-8')
 

--- a/main.py
+++ b/main.py
@@ -141,11 +141,19 @@ def _get_plugin_tsc_version():
     cmd = [get_node_path(), TSC_PATH, "-v"]
     return _execute_cmd_and_parse_version_from_output(cmd)
 
+def _is_executable(path):
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
 def _get_npm_tsc_version():
-    cmd = ["tsc", "-v"]
+    if os.name != 'nt' and _is_executable("/usr/local/bin/tsc"):
+        cmd = ["/usr/local/bin/tsc", "-v"]
+    else:
+        cmd = ["tsc", "-v"]
     return _execute_cmd_and_parse_version_from_output(cmd)
 
 def _execute_cmd_and_parse_version_from_output(cmd):
+    if os.name != 'nt':
+        cmd = "'" + "' '".join(cmd) + "'"
     output = subprocess.check_output(cmd, shell=True).decode('UTF-8')
 
     # Use regex to parse the verion number from <output> e.g. parse


### PR DESCRIPTION
This fixes https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/324.