### PR TITLE
'Default' or 'case' preceded by dot (.) should not be captured as part of switch-case expression.

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -23,7 +23,7 @@ repository:
 
   control-statement:
     name: keyword.control.ts
-    match: \b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|case|default)\b
+    match: (?<!\.)\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|case|default)\b
 
   switch-case: 
     name: case.expr.ts

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -23,14 +23,14 @@ repository:
 
   control-statement:
     name: keyword.control.ts
-    match: \b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super)\b
+    match: \b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|case|default)\b
 
   switch-case: 
     name: case.expr.ts
-    begin: '\b(case|default)\b'
+    begin: '(?<!\.)\b(case|default)\b'
     beginCaptures:
       '1': { name: keyword.control.ts }
-    end: ':'  
+    end: ':'
     patterns:
     - include: '#expression'
 
@@ -389,8 +389,8 @@ repository:
     - include: '#assignment-operator'
     - include: '#storage-keyword'
     - include: '#function-call'
-    - include: '#control-statement'
     - include: '#switch-case'
+    - include: '#control-statement'
     
   for-in-simple:
     name: forin.expr.ts

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -193,7 +193,7 @@
 		<key>control-statement</key>
 		<dict>
 			<key>match</key>
-			<string>\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|case|default)\b</string>
+			<string>(?&lt;!\.)\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|case|default)\b</string>
 			<key>name</key>
 			<string>keyword.control.ts</string>
 		</dict>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -193,7 +193,7 @@
 		<key>control-statement</key>
 		<dict>
 			<key>match</key>
-			<string>\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super)\b</string>
+			<string>\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|case|default)\b</string>
 			<key>name</key>
 			<string>keyword.control.ts</string>
 		</dict>
@@ -362,11 +362,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#control-statement</string>
+					<string>#switch-case</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#switch-case</string>
+					<string>#control-statement</string>
 				</dict>
 			</array>
 		</dict>
@@ -1198,7 +1198,7 @@
 		<key>switch-case</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(case|default)\b</string>
+			<string>(?&lt;!\.)\b(case|default)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -28,14 +28,14 @@ repository:
 
   control-statement:
     name: keyword.control.tsx
-    match: \b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super)\b
+    match: \b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|switch|case)\b
 
   switch-case: 
     name: case.expr.tsx
-    begin: '\b(case|default)\b'
+    begin: '(?<!\.)\b(case|default)\b'
     beginCaptures:
       '1': { name: keyword.control.tsx }
-    end: ':'  
+    end: ':'
     patterns:
     - include: '#expression'
 
@@ -394,8 +394,8 @@ repository:
     - include: '#assignment-operator'
     - include: '#storage-keyword'
     - include: '#function-call'
-    - include: '#control-statement'
     - include: '#switch-case'
+    - include: '#control-statement'
     
   for-in-simple:
     name: forin.expr.tsx

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -28,7 +28,7 @@ repository:
 
   control-statement:
     name: keyword.control.tsx
-    match: \b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|switch|case)\b
+    match: (?<!\.)\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|switch|case)\b
 
   switch-case: 
     name: case.expr.tsx

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -161,7 +161,7 @@
 		<key>control-statement</key>
 		<dict>
 			<key>match</key>
-			<string>\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|switch|case)\b</string>
+			<string>(?&lt;!\.)\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|switch|case)\b</string>
 			<key>name</key>
 			<string>keyword.control.tsx</string>
 		</dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -161,7 +161,7 @@
 		<key>control-statement</key>
 		<dict>
 			<key>match</key>
-			<string>\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super)\b</string>
+			<string>\b(break|catch|continue|debugger|declare|do|else|finally|for|if|return|switch|throw|try|while|with|super|switch|case)\b</string>
 			<key>name</key>
 			<string>keyword.control.tsx</string>
 		</dict>
@@ -330,11 +330,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#control-statement</string>
+					<string>#switch-case</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#switch-case</string>
+					<string>#control-statement</string>
 				</dict>
 			</array>
 		</dict>
@@ -1560,7 +1560,7 @@
 		<key>switch-case</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(case|default)\b</string>
+			<string>(?&lt;!\.)\b(case|default)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
This fixes issue https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/335.