### PR TITLE
Snippets update.

### DIFF
--- a/snippets/method-(fun).sublime-snippet
+++ b/snippets/method-(fun).sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[public ${1:name}(${2:arguments}) : ${3:void} {
+    <content><![CDATA[${1:public} ${2:name}(${3:arguments}) : ${4:void} {
 	${0:// code...}
 }]]></content>
 	<tabTrigger>meth</tabTrigger>

--- a/snippets/namespace.sublime-snippet
+++ b/snippets/namespace.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[namespace ${1:name}{
+	$0
+}]]></content>
+	<tabTrigger>nam</tabTrigger>
+	<scope>source.ts</scope>
+</snippet>


### PR DESCRIPTION
Hi - I noticed the access modifier in the method snippet wasn't a field, so that has been rectified in this PR. I've also added a snippet for `namespace`. Thanks.