### PR TITLE
propertyName should be styled the same way as parameterName in signature popup

### DIFF
--- a/typescript/libs/popup_manager.py
+++ b/typescript/libs/popup_manager.py
@@ -201,7 +201,7 @@ class PopupManager():
                 return 'name'
             elif name in ['keyword', 'interfaceName']:
                 return 'type'
-            elif name in ['parameterName']:
+            elif name in ['parameterName', 'propertyName']:
                 return 'param'
             return 'text'
 


### PR DESCRIPTION
This fixes https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/340.

Before:
![image](https://cloud.githubusercontent.com/assets/1707813/9593312/a7fce5d8-5001-11e5-9f60-eb5e5c5a2f0e.png)

After:
![image](https://cloud.githubusercontent.com/assets/1707813/9593317/b42b2130-5001-11e5-9dbd-9bca2fc9e031.png)