### PR TITLE
Add option to switch off the TypeScript language service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ sublime.py
 sublime_plugin.py
 .idea/*
 .settings/*
+tsserver/node_modules/*

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -4,7 +4,8 @@
         "command": "typescript_paste_and_format",
         "context": [
             { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" },
+            { "key": "setting.enable_typescript_language_service", "operator": "equal", "operand": true }
         ]
     }
 ]

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -1,3 +1,4 @@
 {
-    "typescript_auto_format": true
+    "typescript_auto_format": true,
+    "enable_typescript_language_service": true
 }

--- a/main.py
+++ b/main.py
@@ -60,6 +60,12 @@ def plugin_loaded():
     from on_activated or on_close if necessary.
     """
     log.debug("plugin_loaded started")
+    settings = sublime.load_settings('Preferences.sublime-settings')
+    global_vars._language_service_enabled = settings.get('enable_typescript_language_service', True)
+    print ("lang_service_enabled: " + str(global_vars.get_language_service_enabled()))
+    if not global_vars.get_language_service_enabled():
+        return
+
     cli.initialize()
     ref_view = get_ref_view(False)
     if ref_view:

--- a/typescript/commands/base_command.py
+++ b/typescript/commands/base_command.py
@@ -1,17 +1,18 @@
 import sublime_plugin
+from ..libs.global_vars import get_language_service_enabled
 from ..libs.view_helpers import is_typescript, active_view
 
 
 class TypeScriptBaseTextCommand(sublime_plugin.TextCommand):
     def is_enabled(self):
-        return is_typescript(self.view)
+        return is_typescript(self.view) and get_language_service_enabled()
 
 
 class TypeScriptBaseWindowCommand(sublime_plugin.WindowCommand):
     def is_enabled(self):
-        return is_typescript(self.window.active_view())
+        return is_typescript(self.window.active_view()) and get_language_service_enabled()
 
 
 class TypeScriptBaseApplicationCommand(sublime_plugin.ApplicationCommand):
     def is_enabled(self):
-        return is_typescript(active_view())
+        return is_typescript(active_view()) and get_language_service_enabled()

--- a/typescript/commands/error_list.py
+++ b/typescript/commands/error_list.py
@@ -10,7 +10,7 @@ from .base_command import TypeScriptBaseWindowCommand
 class TypescriptProjectErrorList(sublime_plugin.WindowCommand):
 
     def is_enabled(self):
-        return is_typescript(active_view()) and not global_vars.IS_ST2
+        return is_typescript(active_view()) and not global_vars.IS_ST2 and global_vars.get_language_service_enabled()
 
     def run(self):
         panel_manager = get_panel_manager()
@@ -36,7 +36,7 @@ class TypescriptProjectErrorList(sublime_plugin.WindowCommand):
 class TypescriptGoToError(sublime_plugin.TextCommand):
 
     def is_enabled(self):
-        return not global_vars.IS_ST2
+        return not global_vars.IS_ST2 and global_vars.get_language_service_enabled()
 
     def run(self, text):
         print("TypeScriptGoToError")

--- a/typescript/commands/references.py
+++ b/typescript/commands/references.py
@@ -25,6 +25,9 @@ class TypescriptGoToRefCommand(sublime_plugin.TextCommand):
     """
     If cursor is on reference line, go to (filename, line, offset) referenced by that line
     """
+    def is_enabled(self):
+        return global_vars.get_language_service_enabled()
+
     def run(self, text):
         pos = self.view.sel()[0].begin()
         cursor = self.view.rowcol(pos)
@@ -41,6 +44,9 @@ class TypescriptGoToRefCommand(sublime_plugin.TextCommand):
 
 # TODO: generalize this to work for all types of references
 class TypescriptNextRefCommand(sublime_plugin.TextCommand):
+    def is_enabled(self):
+        return global_vars.get_language_service_enabled()
+
     def run(self, text):
         ref_view = get_ref_view()
         if ref_view:
@@ -54,6 +60,9 @@ class TypescriptNextRefCommand(sublime_plugin.TextCommand):
 # TODO: generalize this to work for all types of references
 class TypescriptPrevRefCommand(sublime_plugin.TextCommand):
     """Go to previous reference in active references file"""
+    def is_enabled(self):
+        return global_vars.get_language_service_enabled()
+
     def run(self, text):
         ref_view = get_ref_view()
         if ref_view:
@@ -70,6 +79,9 @@ class TypescriptPopulateRefs(sublime_plugin.TextCommand):
     Helper command called by TypescriptFindReferences; put the references in the
     references buffer (such as build errors)
     """
+    def is_enabled(self):
+        return global_vars.get_language_service_enabled()
+
     def run(self, text, argsJson):
         args = json_helpers.decode(argsJson)
         file_name = args["filename"]

--- a/typescript/commands/signature.py
+++ b/typescript/commands/signature.py
@@ -60,7 +60,7 @@ class TypescriptSignaturePanel(TypeScriptBaseTextCommand):
 
 class TypescriptSignaturePopup(sublime_plugin.TextCommand):
     def is_enabled(self):
-        return TOOLTIP_SUPPORT and is_typescript(self.view)
+        return TOOLTIP_SUPPORT and is_typescript(self.view) and get_language_service_enabled()
 
     def run(self, edit, move=None):
         log.debug('In run for signature popup with move: {0}'.format(move if move else 'None'))

--- a/typescript/libs/__init__.py
+++ b/typescript/libs/__init__.py
@@ -6,6 +6,7 @@ from .popup_manager import get_popup_manager
 from .logger import log
 from .panel_manager import get_panel_manager
 from . import logger
+from . import global_vars
 __all__ = [
     'cli',
     'EditorClient',
@@ -19,5 +20,6 @@ __all__ = [
     'PopupManager',
     'ServiceProxy',
     'work_scheduler',
+    'global_vars',
     'get_panel_manager'
 ]

--- a/typescript/libs/global_vars.py
+++ b/typescript/libs/global_vars.py
@@ -51,3 +51,7 @@ VALID_COMPLETION_ID_PATTERN = re.compile("[a-zA-Z_$\.][\w$\.]*\Z")
 
 # idle time length in millisecond
 IDLE_TIME_LENGTH = 200
+
+_language_service_enabled = True
+def get_language_service_enabled():
+        return _language_service_enabled

--- a/typescript/libs/view_helpers.py
+++ b/typescript/libs/view_helpers.py
@@ -39,6 +39,9 @@ _file_map_on_worker = dict()
 
 def get_info(view, open_if_not_cached=True):
     """Find the file info on the server that matches the given view"""
+    if not get_language_service_enabled():
+        return
+    
     if not cli.initialized:
         cli.initialize()
 

--- a/typescript/listeners/event_hub.py
+++ b/typescript/listeners/event_hub.py
@@ -1,3 +1,4 @@
+from ..libs import global_vars
 
 class EventHub:
     listener_dict = dict()
@@ -11,12 +12,18 @@ class EventHub:
 
     @classmethod
     def run_listeners(cls, key, *args):
+        if not global_vars.get_language_service_enabled():
+            return
+
         if key in cls.listener_dict.keys():
             for handler in cls.listener_dict[key]:
                 handler(*args)
 
     @classmethod
     def run_listener_with_return(cls, key, *args):
+        if not global_vars.get_language_service_enabled():
+            return None
+
         """Return the first non-None result, otherwise return None"""
         if key in cls.listener_dict.keys():
             res = cls.listener_dict[key][0](*args)


### PR DESCRIPTION
Right now the TypeScript language service is always on. However there have been some request for providing the option to switch it off for reasons like faster browsering sessions on big projects etc.

Related: #402 #164 