### PR TITLE
fix display of screenshots on packagecontrol.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,30 +83,39 @@ The plugin also supports representing a TypeScript project via a [tsconfig.json]
 Screenshots
 ------
 - Project error list
+
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/errorlist.gif)
 
 - Signature popup (Requires [Sublime Text 3](http://www.sublimetext.com/3) build >= 3070)
+ 
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/signature.gif)
 
 - Navigate to symbol
+
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/navigateToSymbol.gif)
 
 - Format
+
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/format.gif)
 
 - Rename
+
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/build_tsconfig.gif)
 
 - Find all references
+
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/find_ref.gif)
 
 - Quick info
+
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/quickinfo.gif)
 
 - Build configured project
+
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/build_tsconfig.gif)
 
 - Build loose file
+
 ![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/build_loose_file.gif)
 
 Reporting Issues


### PR DESCRIPTION
The `packagecontrol.io` [`TypeScript` page](https://packagecontrol.io/packages/TypeScript) displays the screenshots immediately after the description in the bullet point, not on a new line:

<img width="502" src="https://cloud.githubusercontent.com/assets/1776358/11795772/96169508-a286-11e5-8985-e5af4cd8f851.png">

with the first image displaying directly after the text instead of having each image at a uniform place and size. The second bullet text and image display fine because the text is longer, causing the image to wrap. Both lines display correctly on Github. This is because Github-flavored Markdown interprets a single newline in the `.md` source as a `<p>` in the HTML, whereas the original Markdown processor and derivatives require two newlines for a `<p>`. I haven't looked through wbond's source for page rendering, but it appears he doesn't have full GFM compliancy turned on.

At any rate, to make a short story long, I added newlines after each bullet point, so everything should line up nicely now both on Github and `packagecontrol.io`.