### PR TITLE
Update TypeScript.tmLanguage

### DIFF
--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -876,7 +876,7 @@
 		<key>object-declaration</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(?:(export)\s+)?\b(?:(abstract)\s+)?\b(?&lt;!\.)(class|interface)\b</string>
+			<string>\b(?:(export)\s+)?\b(?:(abstract)\s+)?\b(?&lt;!\.)(class\s+|interface)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Include \s+ to class declaration, in case of object with 'class' property, it doesn't breaks color scheme