### PR TITLE
Support customized typescript tsdk location

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,7 +84,6 @@ def plugin_loaded():
     else:
         print("ref view not found")
     log.debug("plugin_loaded ended")
-    _check_typescript_version()
 
 
 def plugin_unloaded():
@@ -98,67 +97,3 @@ def plugin_unloaded():
         if ref_info:
             ref_view.settings().set('refinfo', ref_info.as_value())
     cli.service.exit()
-
-
-_UPDATE_TS_MESSAGE = "Warning from TypeScript Sublime Text plugin:\n\n\
-Detected command-line TypeScript compiler version '{0}'. The TypeScript \
-Sublime Text plugin is using compiler version '{1}'. There may be \
-differences in behavior between releases.\n\n\
-To update your command-line TypeScript compiler to the latest release, run \
-'npm update -g typescript'."
-
-def _check_typescript_version():
-    """
-    Notify user to upgrade npm typescript. Do this only once every time the
-    plugin is updated.
-    """
-    settings = sublime.load_settings('Preferences.sublime-settings')
-    cached_plugin_version = settings.get("typescript_plugin_tsc_version")
-
-    try:
-        plugin_tsc_version = _get_plugin_tsc_version()
-
-        if cached_plugin_version != plugin_tsc_version:
-            # The version number getting from the tsc command is different to
-            # the version number stored in the setting file. This means user
-            # has just updated the plugin.
-
-            npm_tsc_version = _get_npm_tsc_version()
-
-            if npm_tsc_version != plugin_tsc_version:
-                sublime.message_dialog(_UPDATE_TS_MESSAGE.format(
-                    npm_tsc_version, plugin_tsc_version))
-
-                # Update the version in setting file so we don't show this
-                # message twice.
-                settings.set("typescript_plugin_tsc_version", plugin_tsc_version)
-                sublime.save_settings("Preferences.sublime-settings")
-
-    except Exception as error:
-        log.error(error)
-
-def _get_plugin_tsc_version():
-    cmd = [get_node_path(), TSC_PATH, "-v"]
-    return _execute_cmd_and_parse_version_from_output(cmd)
-
-def _is_executable(path):
-    return os.path.isfile(path) and os.access(path, os.X_OK)
-
-def _get_npm_tsc_version():
-    if os.name != 'nt' and _is_executable("/usr/local/bin/tsc"): # Default location on MacOS
-        cmd = [get_node_path(), "/usr/local/bin/tsc", "-v"]
-    else:
-        cmd = ["tsc", "-v"]
-    return _execute_cmd_and_parse_version_from_output(cmd)
-
-def _execute_cmd_and_parse_version_from_output(cmd):
-    if os.name != 'nt': # Linux/MacOS
-        cmd = "'" + "' '".join(cmd) + "'"
-    output = subprocess.check_output(cmd, shell=True).decode('UTF-8')
-
-    # Use regex to parse the verion number from <output> e.g. parse
-    # "1.5.0-beta" from "message TS6029: Version 1.5.0-beta\r\n".
-    match_object = re.search("Version\s*([\w.-]+)", output, re.IGNORECASE)
-    if match_object is None:
-        raise Exception("Cannot parse version number from ouput: '{0}'".format(output))
-    return match_object.groups()[0]

--- a/typescript/commands/build.py
+++ b/typescript/commands/build.py
@@ -18,7 +18,7 @@ class TypescriptBuildCommand(sublime_plugin.WindowCommand):
             if "configFileName" in project_info["body"]:
                 tsconfig_dir = dirname(project_info["body"]["configFileName"])
                 self.window.run_command("exec", {
-                    "cmd": [get_node_path(), TSC_PATH, "-p", tsconfig_dir],
+                    "cmd": [get_node_path(), get_tsc_path(), "-p", tsconfig_dir],
                     # regex to capture build result for displaying in the output panel
                     "file_regex": "^(.+?)\\((\\d+),(\\d+)\\): (.+)$"
                 })
@@ -32,7 +32,7 @@ class TypescriptBuildCommand(sublime_plugin.WindowCommand):
                 )
 
     def compile_inferred_project(self, file_name, params=""):
-        cmd = [get_node_path(), TSC_PATH, file_name]
+        cmd = [get_node_path(), get_tsc_path(), file_name]
         print(cmd)
         if params != "":
             cmd.extend(params.split(' '))

--- a/typescript/libs/editor_client.py
+++ b/typescript/libs/editor_client.py
@@ -49,8 +49,8 @@ class EditorClient:
 
         # retrieve the path to tsserver.js
         # first see if user set the path to the file
-        settings = sublime.load_settings('Preferences.sublime-settings')
-        tsdk_location = settings.get('typescript_tsdk')
+        settings = sublime.load_settings("Preferences.sublime-settings")
+        tsdk_location = settings.get("typescript_tsdk")
         if tsdk_location:
             proc_file = os.path.join(tsdk_location, "tsserver.js")
             global_vars._tsc_path = os.path.join(tsdk_location, "tsc.js")

--- a/typescript/libs/editor_client.py
+++ b/typescript/libs/editor_client.py
@@ -2,6 +2,7 @@
 from .node_client import ServerClient, WorkerClient
 from .service_proxy import ServiceProxy
 from .global_vars import *
+from . import global_vars
 
 
 class ClientFileInfo:
@@ -52,10 +53,13 @@ class EditorClient:
         tsdk_location = settings.get('typescript_tsdk')
         if tsdk_location:
             proc_file = os.path.join(tsdk_location, "tsserver.js")
+            global_vars._tsc_path = os.path.join(tsdk_location, "tsc.js")
         else:
             # otherwise, get tsserver.js from package directory
             proc_file = os.path.join(PLUGIN_DIR, "tsserver", "tsserver.js")
+            global_vars._tsc_path = os.path.join(PLUGIN_DIR, "tsserver", "tsc.js")
         print("Path of tsserver.js: " + proc_file)
+        print("Path of tsc.js: " + get_tsc_path())
 
         self.node_client = ServerClient(proc_file)
         self.worker_client = WorkerClient(proc_file)

--- a/typescript/libs/editor_client.py
+++ b/typescript/libs/editor_client.py
@@ -49,8 +49,10 @@ class EditorClient:
         # retrieve the path to tsserver.js
         # first see if user set the path to the file
         settings = sublime.load_settings('Preferences.sublime-settings')
-        proc_file = settings.get('typescript_proc_file')
-        if not proc_file:
+        tsdk_location = settings.get('typescript_tsdk')
+        if tsdk_location:
+            proc_file = os.path.join(tsdk_location, "tsserver.js")
+        else:
             # otherwise, get tsserver.js from package directory
             proc_file = os.path.join(PLUGIN_DIR, "tsserver", "tsserver.js")
         print("Path of tsserver.js: " + proc_file)

--- a/typescript/libs/global_vars.py
+++ b/typescript/libs/global_vars.py
@@ -34,7 +34,9 @@ _node_path = None
 def get_node_path():
     return _node_path
 
-TSC_PATH = os.path.join(PLUGIN_DIR, "tsserver", "tsc.js")
+_tsc_path = None
+def get_tsc_path():
+    return _tsc_path
 
 # only Sublime Text 3 build after 3072 support tooltip
 TOOLTIP_SUPPORT = int(sublime.version()) >= 3072

--- a/typescript/libs/global_vars.py
+++ b/typescript/libs/global_vars.py
@@ -34,6 +34,7 @@ _node_path = None
 def get_node_path():
     return _node_path
 
+# The tsc.js path will be initialized in the editor_client.py module
 _tsc_path = None
 def get_tsc_path():
     return _tsc_path


### PR DESCRIPTION
Now it uses the same setting name `typescript_tsdk` with VSCode.

Fix #255 
