### PR TITLE
Add missing comma in list declaration, fix #413

### DIFF
--- a/typescript/listeners/listeners.py
+++ b/typescript/listeners/listeners.py
@@ -220,7 +220,7 @@ class TypeScriptEventListener(sublime_plugin.EventListener):
         log.debug("on_post_text_command_with_info")
         if command_name not in \
             ["commit_completion",
-             "insert_best_completion"
+             "insert_best_completion",
              "typescript_format_on_key",
              "typescript_format_document",
              "typescript_format_selection",


### PR DESCRIPTION
The missing comma makes the two distinct list items `"insert_best_completion"` and `"typescript_format_on_key"` concatenate into a single 
`"insert_best_completiontypescript_format_on_key"` list item. The if condition then evaluates to true even when command_name is one of the two names which is clearly not intended.

This change should fix #413. Tab completion emits the "insert_best_completion" command which eventually takes the interpreter to the aforementioned if block and has it call the `reload_buffer` function. I was no longer able to reproduce #413 after this change.