### PR TITLE
Patch snippets formatting

### DIFF
--- a/snippets/function-(fun).sublime-snippet
+++ b/snippets/function-(fun).sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[function ${1:function_name} (${2:argument}) {
+    <content><![CDATA[function ${1:function_name}(${2:argument}) {
 	${0:// body...}
 }]]></content>
     <tabTrigger>func</tabTrigger>

--- a/snippets/log.sublime-snippet
+++ b/snippets/log.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[console.log($1);
-$0]]></content>
+]]></content>
     <tabTrigger>clog</tabTrigger>
     <scope>source.ts, source.tsx</scope>
     <description>console log</description>


### PR DESCRIPTION
Fix for function and log snipptes formatting regarding whitespace. More details in commit messages.