### PR TITLE
Disable auto-format by default

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -1,4 +1,4 @@
 {
-    "typescript_auto_format": true,
+    "typescript_auto_format": false,
     "enable_typescript_language_service": true
 }


### PR DESCRIPTION
As required by many user-logged issues:
https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/387
https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/195
https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/309

It may be better to switch off the auto-formatting by default. This way even when the plugin failed to run, the basic copy / paste function wouldn't be broken.