### PR TITLE
Removes `$` from word_separators Fixes #457

### DIFF
--- a/TypeScript.sublime-settings
+++ b/TypeScript.sublime-settings
@@ -1,4 +1,5 @@
 {
     "auto_complete_triggers" : [ {"selector": "source.ts", "characters": "."} ],
-    "use_tab_stops": false
+    "use_tab_stops": false,
+    "word_separators": "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?"
 }


### PR DESCRIPTION
Prevents '$' from breaking completions.
Also allows proper word selections when variables contain `$` within them.