### PR TITLE
Move popup styling to the active color scheme

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1,31 +1,10 @@
 <style>
-html {
-    background-color: #232628;
-    color: #CCCCCC;
-}
 body {
     font-size: ${fontSize}px;
-    color: #cccc99;
 }
 div {
     margin: 5px;
     word-wrap:break-word;
-}
-a {
-    color: #6699cc;
-}
-.type {
-    color: #60C3E0;
-    font-style: italic;
-}
-.name {
-    color: #60D04E;
-}
-.param {
-    color: #F0AB40;
-}
-.current {
-    text-decoration: underline;
 }
 </style>
 <div><b>${signature}</b></div>


### PR DESCRIPTION
We need ability to change popup colors depending on the active color scheme.
Theme developers should customize them manually. E.g. see [Boxy Theme](https://github.com/oivva/st-boxy/commit/b55345ed42c227e695270efbd55154fb5f8f080b)

![m](https://cloud.githubusercontent.com/assets/9801624/18240102/65b40d6c-7352-11e6-8e31-5b677cb68c87.png)
![o](https://cloud.githubusercontent.com/assets/9801624/18240104/65b7c6dc-7352-11e6-960f-0d2594e21122.png)
![t](https://cloud.githubusercontent.com/assets/9801624/18240101/65b30494-7352-11e6-9dff-ef82919a1c79.png)
![y](https://cloud.githubusercontent.com/assets/9801624/18240103/65b56f7c-7352-11e6-9ac5-bfb67d98ffa9.png)

Closes #498