### PR TITLE
Fix #514

### DIFF
--- a/Default.sublime-mousemap
+++ b/Default.sublime-mousemap
@@ -2,10 +2,8 @@
     {
         "button": "button1",
         "count": 2,
+        "modifiers": ["ctrl"],
         "command": "typescript_go_to_ref",
-        "press_command": "drag_select",
-        "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.find-refs" }
-        ]
+        "press_command": "drag_select"
     }
 ]


### PR DESCRIPTION
Fix #514
Turns out there are no support for `context` in .sublime-mousemap files. Adding a modifier for the double-click short-cut in references view to avoid overriding the global case.