### PR TITLE
Implement quick info tooltip on mouse hover

### DIFF
--- a/typescript/commands/quick_info.py
+++ b/typescript/commands/quick_info.py
@@ -31,9 +31,7 @@ class TypescriptQuickInfoDoc(TypeScriptBaseTextCommand):
     re-runs quick info in case info has changed
     """
 
-    display_point = None
-
-    def handle_quick_info(self, quick_info_resp_dict):
+    def handle_quick_info(self, quick_info_resp_dict, display_point):
         if quick_info_resp_dict["success"]:
             info_str = quick_info_resp_dict["body"]["displayString"]
             status_info_str = info_str
@@ -58,16 +56,15 @@ class TypescriptQuickInfoDoc(TypeScriptBaseTextCommand):
                 html = "<div>" + html_info_str + "</div>"
                 if len(doc_str) > 0:
                     html += "<div>" + html_doc_str + "</div>"
-                self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=self.display_point, max_width=800)
+                self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=display_point, max_width=800)
         else:
             self.view.erase_status("typescript_info")
 
     def run(self, text, hover_point=None):
         check_update_view(self.view)
-        point = self.view.sel()[0].begin() if hover_point is None else hover_point
-        word_at_sel = self.view.classify(point)
+        display_point = self.view.sel()[0].begin() if hover_point is None else hover_point
+        word_at_sel = self.view.classify(display_point)
         if word_at_sel & SUBLIME_WORD_MASK:
-            self.display_point = point
-            cli.service.quick_info(self.view.file_name(), get_location_from_position(self.view, point), self.handle_quick_info)
+            cli.service.quick_info(self.view.file_name(), get_location_from_position(self.view, display_point), lambda response: self.handle_quick_info(response, display_point))
         else:
             self.view.erase_status("typescript_info")

--- a/typescript/commands/quick_info.py
+++ b/typescript/commands/quick_info.py
@@ -31,11 +31,14 @@ class TypescriptQuickInfoDoc(TypeScriptBaseTextCommand):
     re-runs quick info in case info has changed
     """
 
+    display_point = None
+
     def handle_quick_info(self, quick_info_resp_dict):
         if quick_info_resp_dict["success"]:
             info_str = quick_info_resp_dict["body"]["displayString"]
             status_info_str = info_str
             doc_str = quick_info_resp_dict["body"]["documentation"]
+            # process documentation
             if len(doc_str) > 0:
                 if not TOOLTIP_SUPPORT:
                     doc_panel = sublime.active_window().get_output_panel("doc")
@@ -47,20 +50,24 @@ class TypescriptQuickInfoDoc(TypeScriptBaseTextCommand):
                     sublime.active_window().run_command('show_panel', {'panel': 'output.doc'})
                 status_info_str = info_str + " (^T^Q for more)"
             self.view.set_status("typescript_info", status_info_str)
+
+            # process display string
             if TOOLTIP_SUPPORT:
                 html_info_str = escape_html(info_str)
                 html_doc_str = escape_html(doc_str)
                 html = "<div>" + html_info_str + "</div>"
                 if len(doc_str) > 0:
                     html += "<div>" + html_doc_str + "</div>"
-                self.view.show_popup(html, location=-1, max_width=800)
+                self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=self.display_point, max_width=800)
         else:
             self.view.erase_status("typescript_info")
 
-    def run(self, text):
+    def run(self, text, hover_point=None):
         check_update_view(self.view)
-        word_at_sel = self.view.classify(self.view.sel()[0].begin())
+        point = self.view.sel()[0].begin() if hover_point is None else hover_point
+        word_at_sel = self.view.classify(point)
         if word_at_sel & SUBLIME_WORD_MASK:
-            cli.service.quick_info(self.view.file_name(), get_location_from_view(self.view), self.handle_quick_info)
+            self.display_point = point
+            cli.service.quick_info(self.view.file_name(), get_location_from_position(self.view, point), self.handle_quick_info)
         else:
             self.view.erase_status("typescript_info")

--- a/typescript/listeners/__init__.py
+++ b/typescript/listeners/__init__.py
@@ -5,3 +5,4 @@ from .idle import IdleListener
 from .nav_to import NavToEventListener
 from .rename import RenameEventListener
 from .tooltip import TooltipEventListener
+from .quick_info_tool_tip import QuickInfoToolTipEventListener

--- a/typescript/listeners/listeners.py
+++ b/typescript/listeners/listeners.py
@@ -267,3 +267,7 @@ class TypeScriptEventListener(sublime_plugin.EventListener):
     def on_pre_save(self, view):
         log.debug("on_pre_save")
         check_update_view(view)
+
+    def on_hover(self, view, point, hover_zone):
+        log.debug("on_hover")
+        EventHub.run_listeners("on_hover", view, point, hover_zone)

--- a/typescript/listeners/quick_info_tool_tip.py
+++ b/typescript/listeners/quick_info_tool_tip.py
@@ -1,0 +1,11 @@
+from .event_hub import EventHub
+from ..libs.view_helpers import *
+from ..libs.logger import log
+from ..libs import cli
+
+class QuickInfoToolTipEventListener:
+    def on_hover(self, view, point, hover_zone):
+        view.run_command('typescript_quick_info_doc', {"hover_point": point})
+
+listen = QuickInfoToolTipEventListener()
+EventHub.subscribe("on_hover", listen.on_hover)


### PR DESCRIPTION
With sublime build 3118, the new `on_hover` event enables us to show the quick info tooltip when hovering on a symbol.

Example:
![sp160924_011345](https://cloud.githubusercontent.com/assets/1171301/18807115/2c999910-81f4-11e6-978e-51489485e7da.png)
