### PR TITLE
Fix #461: Add fallback to default paste command

### DIFF
--- a/typescript/commands/format.py
+++ b/typescript/commands/format.py
@@ -71,7 +71,17 @@ class TypescriptFormatBrackets(TypeScriptBaseTextCommand):
 
 
 class TypescriptPasteAndFormat(TypeScriptBaseTextCommand):
+    def is_enabled(self):
+        return True
+
     def run(self, text):
+        if is_typescript(self.view) and get_language_service_enabled():
+            self._run(text)
+        else:
+            # fall back to default paste command
+            self.view.run_command('paste')
+
+    def _run(self, text):
         log.debug("running TypescriptPasteAndFormat")
         view = self.view
         check_update_view(view)


### PR DESCRIPTION
I just found an open tab in my browser about issue #461 and realized that I never got around to do this… So, here we go! This actually turned out to be simpler than what I originally expected to do.

This change basically always enables the `typescript_paste_and_format` command but moves the check whether the TypeScript formatter could run inside the execution. If it is not possible, then it falls back to the default `paste` command.

That way, we can safely overwrite the standard keyboard shortcut without breaking paste when TypeScript cannot do this. So we can happily paste into new buffers again—yay!