### PR TITLE
Support inline error tooltip at cursor position

### DIFF
--- a/typescript/commands/error_info.py
+++ b/typescript/commands/error_info.py
@@ -24,8 +24,7 @@ class TypescriptErrorInfo(TypeScriptBaseTextCommand):
 
         if len(error_text) > 0:
             if PHANTOM_SUPPORT:
-                template = '<body><style>div.error {{ background-color: brown; padding: 5px; }}</style><div class="error">{0}</div></body>'
+                template = '<body><style>div.error {{ background-color: brown; padding: 5px; color: white }}</style><div class="error">{0}</div></body>'
                 display_text = template.format(error_text)
                 self.view.add_phantom("typescript_error", self.view.sel()[0], display_text, sublime.LAYOUT_BLOCK)
-            else:
-                self.view.set_status("typescript_error", error_text)
+            self.view.set_status("typescript_error", error_text)

--- a/typescript/commands/error_info.py
+++ b/typescript/commands/error_info.py
@@ -21,7 +21,11 @@ class TypescriptErrorInfo(TypeScriptBaseTextCommand):
             if region.contains(pt):
                 error_text = text
                 break
+
         if len(error_text) > 0:
-            self.view.set_status("typescript_error", error_text)
-        else:
-            self.view.erase_status("typescript_error")
+            if PHANTOM_SUPPORT:
+                template = '<body><style>div.error {{ background-color: brown; padding: 5px; }}</style><div class="error">{0}</div></body>'
+                display_text = template.format(error_text)
+                self.view.add_phantom("typescript_error", self.view.sel()[0], display_text, sublime.LAYOUT_BLOCK)
+            else:
+                self.view.set_status("typescript_error", error_text)

--- a/typescript/libs/global_vars.py
+++ b/typescript/libs/global_vars.py
@@ -42,6 +42,8 @@ def get_tsc_path():
 # only Sublime Text 3 build after 3072 support tooltip
 TOOLTIP_SUPPORT = int(sublime.version()) >= 3072
 
+PHANTOM_SUPPORT = int(sublime.version()) >= 3118
+
 # detect if quick info is available for symbol
 SUBLIME_WORD_MASK = 515
 

--- a/typescript/listeners/idle.py
+++ b/typescript/listeners/idle.py
@@ -171,8 +171,7 @@ class IdleListener:
         # Error info
         if PHANTOM_SUPPORT:
             view.erase_phantoms("typescript_error")
-        else:
-            view.erase_status("typescript_error")
+        view.erase_status("typescript_error")
 
         if info.has_errors:
             view.run_command('typescript_error_info')

--- a/typescript/listeners/idle.py
+++ b/typescript/listeners/idle.py
@@ -169,10 +169,13 @@ class IdleListener:
     def update_status(self, view, info):
         """Update the status line with error info and quick info if no error info"""
         # Error info
-        if info.has_errors:
-            view.run_command('typescript_error_info')
+        if PHANTOM_SUPPORT:
+            view.erase_phantoms("typescript_error")
         else:
             view.erase_status("typescript_error")
+
+        if info.has_errors:
+            view.run_command('typescript_error_info')
 
         # Quick info
         error_status = view.get_status('typescript_error')


### PR DESCRIPTION
The added behavior is quite similar to what we had before. But when the sublime version supports Phantom APIs (> 3118), we show a phantom popup instead of put the error message at the status bar (**only after you click**). The popup will go away when either the error is fixed or when the cursor (**the keyboard cursor** not the mouse cursor) moved to somewhere else. While the "on_hover" tooltip will always show the quick info.

In summary, the workflow is:

* hover with your mouse cursor to get quick info
* click at an error position to see error messages
* errors messages will appear when keyboard cursor is on top of an error span
* click elsewhere to dismiss an error message

![gif](https://cloud.githubusercontent.com/assets/1171301/19293525/f1296f56-8fd9-11e6-9006-96f21ccdf338.gif)
