### PR TITLE
Fix word multi select while holding "ctrl"

### DIFF
--- a/Default.sublime-mousemap
+++ b/Default.sublime-mousemap
@@ -2,7 +2,7 @@
     {
         "button": "button1",
         "count": 2,
-        "modifiers": ["ctrl"],
+        "modifiers": ["ctrl", "alt"],
         "command": "typescript_go_to_ref",
         "press_command": "drag_select"
     }


### PR DESCRIPTION
In Sublime Text (PC/Linux) holding the `ctrl` key allows you to create multiple simultaneous selections with your mouse.

As tracked in issue #518, the fix here from #514 breaks this core functionality.

Adding the `alt` key to this modifiers array (as suggested by @richterdennis) prevents the conflict.