### PR TITLE
Fix missing whitespace in 'if' snippets

### DIFF
--- a/snippets/if-___-else.sublime-snippet
+++ b/snippets/if-___-else.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[if(${1:condition}) { 
+    <content><![CDATA[if (${1:condition}) { 
 	${2:// code...}
 } else {
 	${3:// code...}

--- a/snippets/if.sublime-snippet
+++ b/snippets/if.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[if(${1:condition}) {
+    <content><![CDATA[if (${1:condition}) {
 	${0:// code...}
 }]]></content>
 	<tabTrigger>if</tabTrigger>


### PR DESCRIPTION
The 'If' and 'If Else' snippets are missing a whitespace after 'if' and before the opening bracket.

`if(condition) {
   // code...
}`

`if(condition) { 
  // code...
} else {
  // code...
}`
