### PR TITLE
Fix gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Screenshots
 
 - Rename
 
-![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/build_tsconfig.gif)
+![](https://raw.githubusercontent.com/Microsoft/TypeScript-Sublime-Plugin/master/screenshots/rename.gif)
 
 - Find all references
 


### PR DESCRIPTION
Rename gif is currently build_tsconfig.gif, changed to rename.gif.