### PR TITLE
Support type completion over JavaScript files

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -4,7 +4,7 @@
         "command": "typescript_paste_and_format",
         "context": [
             { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -4,7 +4,7 @@
         "command": "typescript_paste_and_format",
         "context": [
             { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -4,7 +4,7 @@
         "command": "typescript_paste_and_format",
         "context": [
             { "key": "setting.typescript_auto_format", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" },
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" },
             { "key": "setting.enable_typescript_language_service", "operator": "equal", "operand": true }
         ]
     }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -3,14 +3,14 @@
         "keys": [ "ctrl+t", "ctrl+d" ],
         "command": "typescript_go_to_definition",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "f12" ],
         "command": "typescript_go_to_definition",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
@@ -19,14 +19,14 @@
         "context": [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
             { "key": "num_selections", "operator": "equal", "operand": 1, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "ctrl+alt+r"],
         "command": "typescript_nav_to",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
@@ -35,21 +35,21 @@
         "context": [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "num_selections", "operator": "equal", "operand": 1, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "ctrl+t", "ctrl+m" ],
         "command": "typescript_rename",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "ctrl+t", "ctrl+n" ],
         "command": "typescript_next_ref",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
@@ -63,7 +63,7 @@
         "keys": [ "ctrl+t", "ctrl+p" ],
         "command": "typescript_prev_ref",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
@@ -77,35 +77,35 @@
         "keys": [ "ctrl+t", "ctrl+q" ],
         "command": "typescript_quick_info_doc",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "ctrl+t", "ctrl+r" ],
         "command": "typescript_find_references",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "ctrl+t", "ctrl+s" ],
         "command": "typescript_save",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "ctrl+t", "ctrl+o" ],
         "command": "typescript_signature_panel",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": ["("],
         "command": "typescript_signature_popup",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" },
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" },
             { "key": "paren_pressed"}
         ]
     },
@@ -114,7 +114,7 @@
         "command": "typescript_signature_popup",
         "args": {"move": "next"},
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" },
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" },
             { "key": "is_popup_visible"}
         ]
     },
@@ -123,7 +123,7 @@
         "command": "typescript_signature_popup",
         "args": {"move": "prev"},
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" },
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" },
             { "key": "is_popup_visible"}
         ]
     },    // In case when auto match is enabled, only format if not within {}
@@ -131,7 +131,7 @@
         "keys": [ "alt+,"],
         "command": "typescript_signature_popup",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" },
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" },
             { "key": "tooltip_supported", "operator": "equal", "operand": true}
 
         ]
@@ -159,21 +159,21 @@
             { "key": "selection_empty", "operator": "equal", "operand": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\{$" },
             { "key": "following_text", "operator": "regex_contains", "operand": "^\\}" },
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "ctrl+;" ],
         "command": "typescript_format_line",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     },
     {
         "keys": [ "ctrl+shift+]" ],
         "command": "typescript_format_brackets",
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx" }
+            { "key": "selector", "operator": "equal", "operand": "source.ts, source.tsx, source.js, source.jsx" }
         ]
     }
 ]

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -1,5 +1,6 @@
 {
     "typescript_auto_format": false,
     "enable_typescript_language_service": true,
+    "enable_language_service_for_javascript": true,
     "enable_inline_error_tips": false
 }

--- a/typescript/libs/editor_client.py
+++ b/typescript/libs/editor_client.py
@@ -39,6 +39,7 @@ class EditorClient:
         self.ts_auto_format_enabled = True
         self.ts_auto_indent_enabled = True
         self.auto_match_enabled = True
+        self.enable_language_service_for_js = True
 
     def initialize(self):
         """
@@ -65,6 +66,9 @@ class EditorClient:
         self.worker_client = WorkerClient(proc_file)
         self.service = ServiceProxy(self.worker_client, self.node_client)
 
+        settings.add_on_change("enable_language_service_for_javascript", self.load_language_service_setting_for_js)
+        self.load_language_service_setting_for_js()
+
         # load formatting settings and set callbacks for setting changes
         for setting_name in [
             'tab_size',
@@ -78,6 +82,10 @@ class EditorClient:
         self.load_format_settings()
 
         self.initialized = True
+
+    def load_language_service_setting_for_js(self):
+        settings = sublime.load_settings('Preferences.sublime-settings')
+        self.enable_language_service_for_js = settings.get("enable_language_service_for_javascript", True)
 
     def load_format_settings(self):
         settings = sublime.load_settings('Preferences.sublime-settings')

--- a/typescript/libs/service_proxy.py
+++ b/typescript/libs/service_proxy.py
@@ -38,9 +38,9 @@ class ServiceProxy:
         if self.__worker_comm.started():
             self.__worker_comm.postCmd(json_str)
 
-        self.set_compiler_options()
+        self.set_inferred_project_compiler_options()
 
-    def set_compiler_options(self):
+    def set_inferred_project_compiler_options(self):
         """ Add full type support for compilers running in file scope mode """
         compiler_options = {
             "target": "ESNext", # enable all es-next features

--- a/typescript/libs/service_proxy.py
+++ b/typescript/libs/service_proxy.py
@@ -44,7 +44,7 @@ class ServiceProxy:
         """ Add full type support for compilers running in file scope mode """
         compiler_options = {
             "target": "ESNext",
-            "moduleResolution": "CommonJS",
+            "module": "CommonJS",
             "allowSyntheticDefaultImports": True,
             "allowNonTsExtensions": True,
             "allowJs": True,

--- a/typescript/libs/service_proxy.py
+++ b/typescript/libs/service_proxy.py
@@ -43,10 +43,10 @@ class ServiceProxy:
     def set_compiler_options(self):
         """ Add full type support for compilers running in file scope mode """
         compiler_options = {
-            "target": "ESNext",
-            "allowJs": True,
-            "jsx": "Preserve",
-            "noEmit": True
+            "target": "ESNext", # enable all es-next features
+            "allowJs": True,    # enable javascript support
+            "jsx": "Preserve",  # enable jsx support
+            "noEmit": True      # do not emit outputs
         }
         args = { "options": compiler_options }
         req_dict = self.create_req_dict("compilerOptionsForInferredProjects", args)

--- a/typescript/libs/service_proxy.py
+++ b/typescript/libs/service_proxy.py
@@ -47,7 +47,8 @@ class ServiceProxy:
             "module": "CommonJS",
             "allowSyntheticDefaultImports": True,
             "allowJs": True,
-            "jsx": "Preserve"
+            "jsx": "Preserve",
+            "noEmit": True
         }
         args = { "options": compiler_options }
         req_dict = self.create_req_dict("compilerOptionsForInferredProjects", args)

--- a/typescript/libs/service_proxy.py
+++ b/typescript/libs/service_proxy.py
@@ -46,7 +46,6 @@ class ServiceProxy:
             "target": "ESNext",
             "module": "CommonJS",
             "allowSyntheticDefaultImports": True,
-            "allowNonTsExtensions": True,
             "allowJs": True,
             "jsx": "Preserve"
         }

--- a/typescript/libs/service_proxy.py
+++ b/typescript/libs/service_proxy.py
@@ -44,7 +44,6 @@ class ServiceProxy:
         """ Add full type support for compilers running in file scope mode """
         compiler_options = {
             "target": "ESNext",
-            "module": "CommonJS",
             "allowSyntheticDefaultImports": True,
             "allowJs": True,
             "jsx": "Preserve",

--- a/typescript/libs/service_proxy.py
+++ b/typescript/libs/service_proxy.py
@@ -38,6 +38,25 @@ class ServiceProxy:
         if self.__worker_comm.started():
             self.__worker_comm.postCmd(json_str)
 
+        self.set_compiler_options()
+
+    def set_compiler_options(self):
+        """ Add full type support for compilers running in file scope mode """
+        compiler_options = {
+            "target": "ESNext",
+            "moduleResolution": "CommonJS",
+            "allowSyntheticDefaultImports": True,
+            "allowNonTsExtensions": True,
+            "allowJs": True,
+            "jsx": "Preserve"
+        }
+        args = { "options": compiler_options }
+        req_dict = self.create_req_dict("compilerOptionsForInferredProjects", args)
+        json_str = json_helpers.encode(req_dict)
+        self.__comm.postCmd(json_str)
+        if self.__worker_comm.started():
+            self.__worker_comm.postCmd(json_str)
+
     def change(self, path, begin_location=Location(1, 1), end_location=Location(1, 1), insertString=""):
         args = {
             "file": path,

--- a/typescript/libs/service_proxy.py
+++ b/typescript/libs/service_proxy.py
@@ -44,7 +44,6 @@ class ServiceProxy:
         """ Add full type support for compilers running in file scope mode """
         compiler_options = {
             "target": "ESNext",
-            "allowSyntheticDefaultImports": True,
             "allowJs": True,
             "jsx": "Preserve",
             "noEmit": True

--- a/typescript/libs/view_helpers.py
+++ b/typescript/libs/view_helpers.py
@@ -41,7 +41,7 @@ def get_info(view, open_if_not_cached=True):
     """Find the file info on the server that matches the given view"""
     if not get_language_service_enabled():
         return
-    
+
     if not cli.initialized:
         cli.initialize()
 
@@ -106,15 +106,18 @@ def is_typescript(view):
     except:
         return False
 
-    return (view.match_selector(location, 'source.ts') or
-            view.match_selector(location, 'source.tsx'))
+    is_ts_file = view.match_selector(location, 'source.ts, source.tsx')
+    is_js_file = cli.enable_language_service_for_js \
+        and view.match_selector(location, 'source.js, source.jsx')
+
+    return is_ts_file or is_js_file
 
 
 def is_special_view(view):
     """Determine if the current view is a special view.
 
     Special views are mostly referring to panels. They are different from normal views
-    in that they cannot be the active_view of their windows, therefore their ids 
+    in that they cannot be the active_view of their windows, therefore their ids
     shouldn't be equal to the current view id.
     """
     return view is not None and view.window() and view.id() != view.window().active_view().id()
@@ -265,7 +268,7 @@ def reload_required(view):
 def check_update_view(view):
     """Check if the buffer in the view needs to be reloaded
 
-    If we have changes to the view not accounted for by change messages, 
+    If we have changes to the view not accounted for by change messages,
     send the whole buffer through a temporary file
     """
     if is_typescript(view):
@@ -276,7 +279,7 @@ def check_update_view(view):
 
 def send_replace_changes_for_regions(view, regions, insert_string):
     """
-    Given a list of regions and a (possibly zero-length) string to insert, 
+    Given a list of regions and a (possibly zero-length) string to insert,
     send the appropriate change information to the server.
     """
     if not is_typescript(view):

--- a/typescript/listeners/completion.py
+++ b/typescript/listeners/completion.py
@@ -132,6 +132,9 @@ class CompletionEventListener:
             raw_completions = completions_resp["body"]
             if raw_completions:
                 for raw_completion in raw_completions:
+                    # strip unrelated items
+                    if raw_completion["kind"] == "warning":
+                        continue
                     name = raw_completion["name"]
                     completion = (name + "\t" + raw_completion["kind"], name.replace("$", "\\$"))
                     completions.append(completion)


### PR DESCRIPTION
This PR is based on #570, with several fixes and improvements. Apologize if I offended anyone, but I couldn't see any update in #570 for nearly one year 😢.

This implement tries to behave as closely as possible to vscode by:

1. setting `compilerOptionsForInferredProjects` for file scope compilers,
2. excluding items with `kind: "warning"` from completion list.

Screenshot:
![image](https://user-images.githubusercontent.com/6022672/30514546-ce6c19a8-9b51-11e7-819f-0186aea10e1f.png)


