### PR TITLE
Fix issue #604 - GoTo Definition shows all function calling in file

### DIFF
--- a/Symbol List.tmPreferences
+++ b/Symbol List.tmPreferences
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Symbol List</string>
+  <key>scope</key>
+  <string>meta.decorator.ts, meta.var.expr.ts, meta.block.ts, meta.field.declaration.ts</string>
+  <key>settings</key>
+  <dict>
+    <key>showInSymbolList</key>
+    <integer>0</integer>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This is a fix for issue #604 .

I added a 'Symbol List.tmPreferences' file to fix the issue where if you try to go to a function definition, it takes you to the first instance of where the function is used (not necessarily its definition).

I have been using this fix locally for a few weeks now, but this file was removed when I updated my TypeScript plugin.