### PR TITLE
Remove noisy printout in listeners

### DIFF
--- a/typescript/listeners/listeners.py
+++ b/typescript/listeners/listeners.py
@@ -226,7 +226,6 @@ class TypeScriptEventListener(sublime_plugin.EventListener):
              "typescript_format_selection",
              "typescript_format_line",
              "typescript_paste_and_format"]:
-            print(command_name)
             # give up and send whole buffer to server (do this eagerly
             # to avoid lag on next request to server)
             reload_buffer(view, info.client_info)


### PR DESCRIPTION
This print command pollutes the ST console when editing .ts files. Text operations like un/indent and undo/redo result in printouts of "indent", "undo" etc. in the console.