### PR TITLE
Fix region scope

### DIFF
--- a/typescript/commands/error_list.py
+++ b/typescript/commands/error_list.py
@@ -58,7 +58,7 @@ class TypescriptGoToError(sublime_plugin.TextCommand):
         self.view.add_regions(
             "cur_error",
             [sublime.Region(caret_pos, caret_pos + 1)],
-            "keyword",
+            "invalid.illegal",
             icon,
             sublime.HIDDEN
         )

--- a/typescript/listeners/idle.py
+++ b/typescript/listeners/idle.py
@@ -158,10 +158,10 @@ class IdleListener:
 
         # Highlight error regions in view
         if IS_ST2:
-            view.add_regions(region_key, error_regions, "keyword", "",
+            view.add_regions(region_key, error_regions, "invalid", "",
                              sublime.DRAW_OUTLINED)
         else:
-            view.add_regions(region_key, error_regions, "keyword", "",
+            view.add_regions(region_key, error_regions, "invalid.illegal", "",
                              sublime.DRAW_NO_FILL +
                              sublime.DRAW_NO_OUTLINE +
                              sublime.DRAW_SQUIGGLY_UNDERLINE)


### PR DESCRIPTION
Addresses #550. Changes the scope of the error highlights from "keyword" to "invalid.illegal" so themes can control the colors of the highlights.