### PR TITLE
Fix auto completion support in .js files

### DIFF
--- a/JavaScript.sublime-settings
+++ b/JavaScript.sublime-settings
@@ -1,0 +1,5 @@
+{
+    "auto_complete_triggers" : [ {"selector": "source.js", "characters": "."} ],
+    "use_tab_stops": false,
+    "word_separators": "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?"
+}


### PR DESCRIPTION
Simply copied those in [`TypeScript.sublime-settings`](https://github.com/Microsoft/TypeScript-Sublime-Plugin/blob/9be83665f84f580d832271010d140e8cd98e41e2/TypeScript.sublime-settings) to `JavaScript.sublime-settings`.

Fix #692 

CC @DanielRosenwasser