### PR TITLE
Add '.' as a completion trigger for JavaScript scopes.

### DIFF
--- a/JavaScript.sublime-settings
+++ b/JavaScript.sublime-settings
@@ -1,0 +1,5 @@
+{
+    "auto_complete_triggers" : [ {"selector": "source.js", "characters": "."} ],
+    "use_tab_stops": false,
+    "word_separators": "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?"
+}


### PR DESCRIPTION
Copied from the 'TypeScript.sublime-settings' file.

Fixes #692.