### PR TITLE
Don't filter "warning" completions

### DIFF
--- a/typescript/listeners/completion.py
+++ b/typescript/listeners/completion.py
@@ -132,9 +132,6 @@ class CompletionEventListener:
             raw_completions = completions_resp["body"]
             if raw_completions:
                 for raw_completion in raw_completions:
-                    # strip unrelated items
-                    if raw_completion["kind"] == "warning":
-                        continue
                     name = raw_completion["name"]
                     completion = (name + "\t" + raw_completion["kind"], name.replace("$", "\\$"))
                     completions.append(completion)


### PR DESCRIPTION
This is to avoid disrupting JavaScript editing scenarios, since users may be frustrated when types declarations are not available. VS Code actually has this behind a flag and lets them flow in by default.

@idiotWu