### PR TITLE
Changes default max width of HTML popup view from 1500 to 1024; adds error_color and quick_info_popup_max_width settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,21 @@ The below features are available via the keyboard shortcuts shown, or via the Co
 |Build		        | (Win)`^B` or `F7`, (OSX) `⌘B` or `F7`   |
 |Error list             | (via Command Palette) |
 
-The "format on key" feature is on by default, which formats the current line after typing `;`, `}` or `enter`.
-To disable it, go to `Preferences` -> `Package Settings` -> `TypeScript` -> `Plugin Settings - User`, and add
-`"typescript_auto_format": false` to the json file.
+The "format on key" feature is disabled by default, which formats the current line after typing `;`, `}` or `enter`.
+To enable it, go to `Preferences` -> `Package Settings` -> `TypeScript` -> `Plugin Settings - User`, and add `"typescript_auto_format": true` to the json file.
 
 For further information about the keyboard shortcuts, please refer to the [`Default.sublime-keymap`](https://github.com/Microsoft/TypeScript-Sublime-Plugin/blob/master/Default.sublime-keymap) file for common shortcuts and
 [`Default (OSX).sublime-keymap`](https://github.com/Microsoft/TypeScript-Sublime-Plugin/blob/master/Default%20(OSX).sublime-keymap),
 [`Default (Windows).sublime-keymap`](https://github.com/Microsoft/TypeScript-Sublime-Plugin/blob/master/Default%20(Windows).sublime-keymap),
 [`Default (Linux).sublime-keymap`](https://github.com/Microsoft/TypeScript-Sublime-Plugin/blob/master/Default%20(Linux).sublime-keymap)
 for OS-specific shortcuts.
+
+#### Other settings
+
+These settings can be overridden in `Packages/User/TypeScript.sublime-settings`, which you can open by going to `Preferences` -> `Package Settings` -> `TypeScript` -> `TypeScript Settings - User`.
+
+- `error_color`: the color of the squiggly lines drawn underneath type errors; either an empty string for the default color, or one of `"region.redish"`, `"region.orangish"`, `"region.yellowish"`, `"region.greenish"`, `"region.bluish"`, `"region.purplish"`, `"region.pinkish"`
+- `quick_info_popup_max_width`: the max width of the quick info popup, default 1024
 
 Project System
 ------

--- a/TypeScript.sublime-settings
+++ b/TypeScript.sublime-settings
@@ -1,5 +1,9 @@
 {
     "auto_complete_triggers" : [ {"selector": "source.ts", "characters": "."} ],
     "use_tab_stops": false,
-    "word_separators": "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?"
+    "word_separators": "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?",
+
+    // empty string, or one of "region.redish", "region.orangish", "region.yellowish", "region.greenish", "region.bluish", "region.purplish", "region.pinkish"
+    "error_color": "",
+    "quick_info_popup_max_width": 1024
 }

--- a/typescript/commands/quick_info.py
+++ b/typescript/commands/quick_info.py
@@ -66,7 +66,7 @@ class TypescriptQuickInfoDoc(TypeScriptBaseTextCommand):
                 self.template = Template(load_quickinfo_and_error_popup_template())
             text_parts = { "error": error_html, "info_str": escape_html(info_str), "doc_str": escape_html(doc_str) }
             html = self.template.substitute(text_parts)
-            self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=display_point, max_height=300, max_width=1500)
+            self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=display_point, max_height=300, max_width=1024)
 
     def get_error_text_html(self, pt):
         client_info = cli.get_or_add_file(self.view.file_name())

--- a/typescript/commands/quick_info.py
+++ b/typescript/commands/quick_info.py
@@ -66,7 +66,9 @@ class TypescriptQuickInfoDoc(TypeScriptBaseTextCommand):
                 self.template = Template(load_quickinfo_and_error_popup_template())
             text_parts = { "error": error_html, "info_str": escape_html(info_str), "doc_str": escape_html(doc_str) }
             html = self.template.substitute(text_parts)
-            self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=display_point, max_height=300, max_width=1024)
+
+            settings = sublime.load_settings("TypeScript.sublime-settings")
+            self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=display_point, max_height=300, max_width=settings.get("quick_info_popup_max_width") or 1024)
 
     def get_error_text_html(self, pt):
         client_info = cli.get_or_add_file(self.view.file_name())

--- a/typescript/commands/quick_info.py
+++ b/typescript/commands/quick_info.py
@@ -68,7 +68,7 @@ class TypescriptQuickInfoDoc(TypeScriptBaseTextCommand):
             html = self.template.substitute(text_parts)
 
             settings = sublime.load_settings("TypeScript.sublime-settings")
-            self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=display_point, max_height=300, max_width=settings.get("quick_info_popup_max_width") or 1024)
+            self.view.show_popup(html, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY, location=display_point, max_height=300, max_width=settings.get("quick_info_popup_max_width") or self.view.viewport_extent()[0])
 
     def get_error_text_html(self, pt):
         client_info = cli.get_or_add_file(self.view.file_name())

--- a/typescript/listeners/idle.py
+++ b/typescript/listeners/idle.py
@@ -161,7 +161,8 @@ class IdleListener:
             view.add_regions(region_key, error_regions, "invalid", "",
                              sublime.DRAW_OUTLINED)
         else:
-            view.add_regions(region_key, error_regions, "invalid.illegal", "",
+            settings = sublime.load_settings("TypeScript.sublime-settings")
+            view.add_regions(region_key, error_regions, settings.get("error_color") or "invalid.illegal", "",
                              sublime.DRAW_NO_FILL +
                              sublime.DRAW_NO_OUTLINE +
                              sublime.DRAW_SQUIGGLY_UNDERLINE)


### PR DESCRIPTION
The smallest screen resolution for laptops with a significant number of users worldwide is **1024×768 (xga – standard)**.

This PR lowers the max_width of the quick info popup from 1500 to 1024. Popups with a width of 1500 aren't properly visible on many laptops, including my 13 inch MBP, which has a width of 1280.

It also adds `error_color` and `quick_info_popup_max_width` settings, which can be overridden in `Packages/User/TypeScript.sublime-settings`.

The `error_color` setting would properly solve issues like #489 .

Here's a screenshot to illustrate the popup width issue:

<img width="1091" alt="Screen Shot 2019-04-28 at 10 22 08 AM" src="https://user-images.githubusercontent.com/1524088/56866565-2cdee600-69a0-11e9-892c-1844a1de100d.png">

And here's a screenshot to show type errors underlined in red, using `"error_color": "region.redish"`. The possible error colors are limited by the Sublime Text API. The method used in this PR is the same as the method used by the [Bracket Highlighter plugin](http://facelessuser.github.io/BracketHighlighter/customize/#configuring-highlight-style). See **Clearing Up Color Misconceptions** for a detailed explanation.

<img width="824" alt="Screen Shot 2019-04-30 at 8 07 32 AM" src="https://user-images.githubusercontent.com/1524088/56963643-0b583880-6b1f-11e9-9cd7-97c459af5403.png">
