### PR TITLE
Configurable error visibility options and gutter errors tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ for OS-specific shortcuts.
 
 These settings can be overridden in `Packages/User/TypeScript.sublime-settings`, which you can open by going to `Preferences` -> `Package Settings` -> `TypeScript` -> `TypeScript Settings - User`.
 
-- `error_color`: the color of the squiggly lines drawn underneath type errors; either an empty string for the default color, or one of `"region.redish"`, `"region.orangish"`, `"region.yellowish"`, `"region.greenish"`, `"region.bluish"`, `"region.purplish"`, `"region.pinkish"`
+- `error_color`: the color of the lines drawn underneath/around type errors; either an empty string for the default color, or one of `"region.redish"`, `"region.orangish"`, `"region.yellowish"`, `"region.greenish"`, `"region.bluish"`, `"region.purplish"`, `"region.pinkish"`
+- `error_icon`: specifies a gutter icon, defaults to nothing cab be set to `"dot"`, `"circle"`, `"bookmark"` or any other value accepted by Sublime Text
+- `error_outlined`: will draw type errors with a solid outline instead of the default which is a squiggly line underneath
 - `quick_info_popup_max_width`: the max width of the quick info popup, default 1024
 
 Project System

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ for OS-specific shortcuts.
 These settings can be overridden in `Packages/User/TypeScript.sublime-settings`, which you can open by going to `Preferences` -> `Package Settings` -> `TypeScript` -> `TypeScript Settings - User`.
 
 - `error_color`: the color of the lines drawn underneath/around type errors; either an empty string for the default color, or one of `"region.redish"`, `"region.orangish"`, `"region.yellowish"`, `"region.greenish"`, `"region.bluish"`, `"region.purplish"`, `"region.pinkish"`
-- `error_icon`: specifies a gutter icon, defaults to nothing cab be set to `"dot"`, `"circle"`, `"bookmark"` or any other value accepted by Sublime Text
+- `error_icon`: specifies a gutter icon, defaults to nothing can be set to `"dot"`, `"circle"`, `"bookmark"` or any other value accepted by Sublime Text
 - `error_outlined`: will draw type errors with a solid outline instead of the default which is a squiggly line underneath
 - `quick_info_popup_max_width`: the max width of the quick info popup, default 1024
 

--- a/TypeScript.sublime-settings
+++ b/TypeScript.sublime-settings
@@ -5,5 +5,7 @@
 
     // empty string, or one of "region.redish", "region.orangish", "region.yellowish", "region.greenish", "region.bluish", "region.purplish", "region.pinkish"
     "error_color": "",
+    "error_icon": "",
+    "error_outlined": false,
     "quick_info_popup_max_width": 1024
 }

--- a/typescript/listeners/idle.py
+++ b/typescript/listeners/idle.py
@@ -162,7 +162,12 @@ class IdleListener:
                              sublime.DRAW_OUTLINED)
         else:
             settings = sublime.load_settings("TypeScript.sublime-settings")
-            view.add_regions(region_key, error_regions, settings.get("error_color") or "invalid.illegal", "",
+            view.add_regions(region_key,
+                             error_regions,
+                             settings.get("error_color", "invalid.illegal"),
+                             settings.get("error_icon", ""),
+                             sublime.DRAW_OUTLINED
+                             if settings.get("error_outlined") else
                              sublime.DRAW_NO_FILL +
                              sublime.DRAW_NO_OUTLINE +
                              sublime.DRAW_SQUIGGLY_UNDERLINE)

--- a/typescript/listeners/quick_info_tool_tip.py
+++ b/typescript/listeners/quick_info_tool_tip.py
@@ -5,7 +5,7 @@ from ..libs import cli
 
 class QuickInfoToolTipEventListener:
     def on_hover(self, view, point, hover_zone):
-        view.run_command('typescript_quick_info_doc', {"hover_point": point})
+        view.run_command('typescript_quick_info_doc', {"hover_point": point, "hover_zone": hover_zone})
 
 listen = QuickInfoToolTipEventListener()
 EventHub.subscribe("on_hover", listen.on_hover)


### PR DESCRIPTION
Implements two additional configuration options, one for setting an optional gutter icon on lines with errors and one for switching from default squiggly line to solid outline. This is superset of PR #625 functionality.

Also adds a gutter tooltip to show all errors on a line.

Fixes #522 #711

Thoughts and feedback welcome.