### PR TITLE
#604 - Updated symbols list

### DIFF
--- a/Symbols.tmPreferences
+++ b/Symbols.tmPreferences
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Symbol List</string>
+  <key>scope</key>
+  <string>meta.decorator.ts, meta.var.expr.ts, meta.block.ts, meta.field.declaration.ts</string>
+  <key>settings</key>
+  <dict>
+    <key>showInSymbolList</key>
+    <integer>0</integer>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #604 where symbol list will show all references to a given function in a file instead of just the function definition.

This is the exact change proposed in #653, but the original author of that change abandoned it.