### PR TITLE
prevent interruption to tab based autocompletion

### DIFF
--- a/typescript/listeners/completion.py
+++ b/typescript/listeners/completion.py
@@ -106,7 +106,7 @@ class CompletionEventListener:
             info.last_completion_loc = locations[0]
             self.pending_completions = []
             self.completions_ready = False
-            return completions, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS
+            return completions, sublime.INHIBIT_EXPLICIT_COMPLETIONS
 
     def handle_completion_info(self, completions_resp):
         """Helper callback when completion info received from server"""


### PR DESCRIPTION
this PR is a small change that fixes an issue with the expected behavior of sublime text after installing this plugin. 

currently, with the plugin installed, when you type a word fragment and then press `tab`, if typescript does not have any suggestions for autocomplete, then sublime will insert a literal tab/spaces. without the plugin, however, sublime would allow you to tab through several autocomplete suggested words (pulled from matching words in the current document).

the flag that this PR removes (described [here](http://docs.sublimetext.info/en/latest/reference/api.html#sublime_plugin.EventListener.on_query_completions)), makes it so that sublime's standard list of words offered up as part of tab completion are not wiped out. essentially, this restores the expected behavior of typing a word fragment and then hitting `tab` within sublime.

if the reviewers would like, i'd be happy to make this part of the plugin config; it is unclear to me if this flag was set deliberately or not.

interestingly, i think other people previously were trying to raise this same issue, but there was some confusion because of the ambiguity of the phrase "autocomplete does not work". that could mean "when i press tab, the thing i'm used to sublime doing no longer happens", or it could mean "when i try to use autocomplete from this plugin, no results are suggested by tsserver". here are a few where i think this may have been the case: https://github.com/microsoft/TypeScript-Sublime-Plugin/pull/445, https://github.com/microsoft/TypeScript-Sublime-Plugin/issues/442, https://github.com/microsoft/TypeScript-Sublime-Plugin/issues/512