### PR TITLE
Add setting to manage word completions inhibition

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ These settings can be overridden in `Packages/User/TypeScript.sublime-settings`,
 - `node_args`: array of command line arguments sent to the tsserver Node.js process before the tsserver script path (useful for e.g. changing max heap size or attaching debugger to the tsserver process)
 - `tsserver_args`: array of command line arguments sent to tsserver Node.js process after the tsserver script path (useful for e.g. overriding tsserver error message locale)
 - `tsserver_env`: environment variables to set for the tsserver Node.js process (useful for e.g. setting `TSS_LOG`). These variables are merged with the environment variables available to Sublime.
-- `auto_complete_api_completions_only`: boolean to make the autocompletion only provides typescript suggestions and hides the standard completions (aka, all the words of the pages). (Default value: `false`). 
+- `auto_complete_api_completions_only`: boolean to make the autocompletion only provides typescript suggestions and hides the standard completions (aka, all the words of the page). (Default value: `false`). 
 
 Project System
 ------

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ These settings can be overridden in `Packages/User/TypeScript.sublime-settings`,
 - `node_args`: array of command line arguments sent to the tsserver Node.js process before the tsserver script path (useful for e.g. changing max heap size or attaching debugger to the tsserver process)
 - `tsserver_args`: array of command line arguments sent to tsserver Node.js process after the tsserver script path (useful for e.g. overriding tsserver error message locale)
 - `tsserver_env`: environment variables to set for the tsserver Node.js process (useful for e.g. setting `TSS_LOG`). These variables are merged with the environment variables available to Sublime.
+- `auto_complete_api_completions_only`: boolean to make the autocompletion only provides typescript suggestions and hides the standard completions (aka, all the words of the pages). (Default value: `false`). 
 
 Project System
 ------

--- a/TypeScript.sublime-settings
+++ b/TypeScript.sublime-settings
@@ -1,6 +1,5 @@
 {
     "auto_complete_triggers" : [ {"selector": "source.ts", "characters": "."} ],
-    "auto_complete_inhibit_word_completions": false,
     "use_tab_stops": false,
     "word_separators": "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?",
 

--- a/TypeScript.sublime-settings
+++ b/TypeScript.sublime-settings
@@ -1,5 +1,6 @@
 {
     "auto_complete_triggers" : [ {"selector": "source.ts", "characters": "."} ],
+    "auto_complete_api_completions_only": false,
     "use_tab_stops": false,
     "word_separators": "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?",
 

--- a/TypeScript.sublime-settings
+++ b/TypeScript.sublime-settings
@@ -1,5 +1,6 @@
 {
     "auto_complete_triggers" : [ {"selector": "source.ts", "characters": "."} ],
+    "auto_complete_inhibit_word_completions": false,
     "use_tab_stops": false,
     "word_separators": "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?",
 

--- a/typescript/listeners/completion.py
+++ b/typescript/listeners/completion.py
@@ -106,7 +106,15 @@ class CompletionEventListener:
             info.last_completion_loc = locations[0]
             self.pending_completions = []
             self.completions_ready = False
-            return completions, sublime.INHIBIT_EXPLICIT_COMPLETIONS
+
+            flags = None
+            settings = sublime.load_settings("TypeScript.sublime-settings")
+            if settings.get('auto_complete_inhibit_word_completions', 'false'):
+                flags = sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS
+            else:
+                flags = sublime.INHIBIT_EXPLICIT_COMPLETIONS
+
+            return completions, flags
 
     def handle_completion_info(self, completions_resp):
         """Helper callback when completion info received from server"""

--- a/typescript/listeners/completion.py
+++ b/typescript/listeners/completion.py
@@ -142,9 +142,10 @@ class CompletionEventListener:
                 self.run_auto_complete()
 
     def run_auto_complete(self):
+        settings = sublime.load_settings("TypeScript.sublime-settings")
         active_view().run_command("auto_complete", {
             'disable_auto_insert': True,
-            'api_completions_only': False,
+            'api_completions_only': settings.get('auto_complete_api_completions_only', False),
             'next_completion_if_showing': False,
             'auto_complete_commit_on_tab': True,
         })

--- a/typescript/listeners/completion.py
+++ b/typescript/listeners/completion.py
@@ -106,15 +106,7 @@ class CompletionEventListener:
             info.last_completion_loc = locations[0]
             self.pending_completions = []
             self.completions_ready = False
-
-            flags = None
-            settings = sublime.load_settings("TypeScript.sublime-settings")
-            if settings.get('auto_complete_inhibit_word_completions', 'false'):
-                flags = sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS
-            else:
-                flags = sublime.INHIBIT_EXPLICIT_COMPLETIONS
-
-            return completions, flags
+            return completions, sublime.INHIBIT_EXPLICIT_COMPLETIONS
 
     def handle_completion_info(self, completions_resp):
         """Helper callback when completion info received from server"""


### PR DESCRIPTION
#733 created a regression (see my comment : https://github.com/microsoft/TypeScript-Sublime-Plugin/pull/733#commitcomment-37663896)

This PR adds a simple setting key to switch between old and new behavior.

Default behavior is the new one. 
Turning setting `auto_complete_inhibit_word_completions` to True activates the old one.

I hope you will be OK with that.