### PR TITLE
Replaced start up useless excessive printing by log.debug() calls, issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,7 +62,7 @@ def plugin_loaded():
     log.debug("plugin_loaded started")
     settings = sublime.load_settings('Preferences.sublime-settings')
     global_vars._language_service_enabled = settings.get('enable_typescript_language_service', True)
-    print ("lang_service_enabled: " + str(global_vars.get_language_service_enabled()))
+    log.debug ("lang_service_enabled: " + str(global_vars.get_language_service_enabled()))
     if not global_vars.get_language_service_enabled():
         return
 
@@ -72,7 +72,7 @@ def plugin_loaded():
         settings = ref_view.settings()
         ref_info_view = settings.get('refinfo')
         if ref_info_view:
-            print("got refinfo from settings")
+            log.debug("got refinfo from settings")
             ref_info = build_ref_info(ref_info_view)
             cli.update_ref_info(ref_info)
             ref_view.set_scratch(True)
@@ -81,14 +81,14 @@ def plugin_loaded():
             if cur_line:
                 update_ref_line(ref_info, int(cur_line), ref_view)
             else:
-                print("no current ref line")
+                log.debug("no current ref line")
         else:
             window = sublime.active_window()
             if window:
                 window.focus_view(ref_view)
                 window.run_command('close')
     else:
-        print("ref view not found")
+        log.debug("ref view not found")
     log.debug("plugin_loaded ended")
 
 

--- a/typescript/libs/editor_client.py
+++ b/typescript/libs/editor_client.py
@@ -1,6 +1,7 @@
 ﻿from .reference import RefInfo
 from .node_client import ServerClient, WorkerClient
 from .service_proxy import ServiceProxy
+from .logger import log
 from .global_vars import *
 from . import global_vars
 
@@ -59,8 +60,8 @@ class EditorClient:
             # otherwise, get tsserver.js from package directory
             proc_file = os.path.join(PLUGIN_DIR, "tsserver", "tsserver.js")
             global_vars._tsc_path = os.path.join(PLUGIN_DIR, "tsserver", "tsc.js")
-        print("Path of tsserver.js: " + proc_file)
-        print("Path of tsc.js: " + get_tsc_path())
+        log.debug("Path of tsserver.js: " + proc_file)
+        log.debug("Path of tsc.js: " + get_tsc_path())
 
         self.node_client = ServerClient(proc_file)
         self.worker_client = WorkerClient(proc_file)

--- a/typescript/libs/node_client.py
+++ b/typescript/libs/node_client.py
@@ -263,7 +263,7 @@ class ServerClient(NodeCommClient):
             self.server_proc = None
         else:
             global_vars._node_path = node_path
-            print("Trying to spawn node executable from: " + node_path)
+            log.debug("Trying to spawn node executable from: " + node_path)
             try:
                 node_process_cmd = [node_path] + node_args + [script_path, "--disableAutomaticTypingAcquisition"] + tsserver_args
                 if os.name == "nt":


### PR DESCRIPTION
What is this print("ref view not found") going out to console when I start Sublime Text?

fix #647