### PR TITLE
Add config to exclude name and path suggestions

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -2,5 +2,7 @@
     "typescript_auto_format": false,
     "enable_typescript_language_service": true,
     "enable_language_service_for_javascript": true,
-    "enable_inline_error_tips": false
+    "enable_inline_error_tips": false,
+    "auto_complete_suggest_names" : true,
+    "auto_complete_suggest_paths" : true
 }

--- a/README.md
+++ b/README.md
@@ -102,9 +102,14 @@ These settings can be overridden in `Packages/User/TypeScript.sublime-settings`,
 - `error_icon`: specifies a gutter icon, defaults to nothing can be set to `"dot"`, `"circle"`, `"bookmark"` or any other value accepted by Sublime Text
 - `error_outlined`: will draw type errors with a solid outline instead of the default which is a squiggly line underneath
 - `quick_info_popup_max_width`: the max width of the quick info popup, default 1024
+
+These settings can be overridden in `Packages/User/Preferences.sublime-settings`, which you can open by going to `Preferences` -> `Settings`.
+
 - `node_args`: array of command line arguments sent to the tsserver Node.js process before the tsserver script path (useful for e.g. changing max heap size or attaching debugger to the tsserver process)
 - `tsserver_args`: array of command line arguments sent to tsserver Node.js process after the tsserver script path (useful for e.g. overriding tsserver error message locale)
 - `tsserver_env`: environment variables to set for the tsserver Node.js process (useful for e.g. setting `TSS_LOG`). These variables are merged with the environment variables available to Sublime.
+- `auto_complete_suggest_names`: set to false to exclude name suggestions
+- `auto_complete_suggest_paths`: set to false to exclude path suggestions
 
 Project System
 ------

--- a/typescript/listeners/completion.py
+++ b/typescript/listeners/completion.py
@@ -131,7 +131,10 @@ class CompletionEventListener:
             completions = []
             raw_completions = completions_resp["body"]
             if raw_completions:
+                settings = sublime.load_settings("Preferences.sublime-settings")
                 for raw_completion in raw_completions:
+                    if self.should_exclude_completion_entry(settings, raw_completion):
+                        continue
                     name = raw_completion["name"]
                     completion = (name + "\t" + raw_completion["kind"], name.replace("$", "\\$"))
                     completions.append(completion)
@@ -140,6 +143,10 @@ class CompletionEventListener:
                 self.completions_ready = True
                 active_view().run_command('hide_auto_complete')
                 self.run_auto_complete()
+
+    def should_exclude_completion_entry(self, settings, completion_entry):
+        return ((not settings.get("auto_complete_suggest_names", True) and completion_entry["kind"] == "warning")
+            or (not settings.get("auto_complete_suggest_paths", True) and completion_entry["kind"] in ["directory", "script", "module"]))
 
     def run_auto_complete(self):
         active_view().run_command("auto_complete", {


### PR DESCRIPTION
I was annoyed by the all the irrelevant "warning" suggestions, so I decided to implement a function similar to [`shouldExcludeCompletionEntry` in vscode](https://github.com/microsoft/vscode/blob/master/extensions/typescript-language-features/src/features/completions.ts#L789). The default behaviour stays the same i.e. all suggestions are included.

Please review, cheers.

Related to microsoft/TypeScript-Sublime-Plugin#699 raised by @DanielRosenwasser 