### PR TITLE
Improve typescript_tsdk lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,31 @@ The plug-in uses **Node.js** to run the TypeScript server.  The plug-in looks fo
 If the `node_path` setting is present, this will override the PATH environment variable and the plug-in will use the value of the `node_path` setting as the node executable to run.
 See more information in [our Tips and Known Issues](https://github.com/Microsoft/TypeScript-Sublime-Plugin/wiki/Tips-and-Known-Issues) wiki page.
 
-Note: Using different versions of TypeScript
+Using different versions of TypeScript
 --------------
-This plugin can be configured to load an alternate version of TypeScript.
-This is typically useful for trying out nightly builds, or prototyping with custom builds.
-To do that, update the `Settings - User` file with the following:
+
+This plugin can be configured to load an alternate version of TypeScript. This is typically useful for trying out nightly builds, prototyping with custom builds, or compatibility with node_modules-free package managers like Yarn 2. To do that, update the `Settings - User` file or your project settings with the following:
 
 ```json5
 "typescript_tsdk": "<path to your folder>/node_modules/typescript/lib"
 ```
+
+The path may be relative. In such case the plugin will look in the following locations in this order:
+
+```
+/foo/project_folder_1/<typescript_tsdk>
+/foo/<typescript_tsdk>
+/<typescript_tsdk>
+/bar/project_folder_2/<typescript_tsdk>
+/bar/<typescript_tsdk>
+/baz/open_file_1_folder/<typescript_tsdk>
+/baz/<typescript_tsdk>
+/baz/open_file_2_folder/<typescript_tsdk>
+```
+
+In case of Yarn 2, just [install its editor SDK](https://yarnpkg.com/advanced/editor-sdks) and set `typescript_tsdk` to `.vscode/pnpify/typescript/lib`.
+
+**Note.** The plugin isn't reloaded when switching projects or updating settings at the moment, so you must restart Sublime Text when doing so, unfortunately. When in doubt, check the console for "Path of tsserver.js" and "Path of tsc.js", and see if they point where you expect them to point.
 
 Installation
 ------------

--- a/typescript/libs/editor_client.py
+++ b/typescript/libs/editor_client.py
@@ -1,4 +1,7 @@
-﻿from .reference import RefInfo
+﻿import collections
+import logging
+
+from .reference import RefInfo
 from .node_client import ServerClient, WorkerClient
 from .service_proxy import ServiceProxy
 from .logger import log
@@ -49,19 +52,53 @@ class EditorClient:
         initialized during loading time
         """
 
-        # retrieve the path to tsserver.js
-        # first see if user set the path to the file
-        settings = sublime.load_settings("Preferences.sublime-settings")
-        tsdk_location = settings.get("typescript_tsdk")
-        if tsdk_location:
-            proc_file = os.path.join(tsdk_location, "tsserver.js")
-            global_vars._tsc_path = os.path.join(tsdk_location, "tsc.js")
-        else:
-            # otherwise, get tsserver.js from package directory
-            proc_file = os.path.join(PLUGIN_DIR, "tsserver", "tsserver.js")
-            global_vars._tsc_path = os.path.join(PLUGIN_DIR, "tsserver", "tsc.js")
-        log.debug("Path of tsserver.js: " + proc_file)
-        log.debug("Path of tsc.js: " + get_tsc_path())
+        # Default to and fall back to the bundled SDK
+        tsdk_location_default = os.path.join(PLUGIN_DIR, "tsserver")
+        tsdk_location = tsdk_location_default
+
+        is_tsdk_location_good = lambda x: (
+            os.path.isfile(os.path.join(x, "tsserver.js"))
+            and os.path.isfile(os.path.join(x, "tsc.js"))
+        )
+
+        active_window = sublime.active_window()
+        settings = active_window.active_view().settings()
+        typescript_tsdk_setting = settings.get("typescript_tsdk")
+        if typescript_tsdk_setting:
+            if os.path.isabs(typescript_tsdk_setting):
+                if is_tsdk_location_good(typescript_tsdk_setting):
+                    tsdk_location = typescript_tsdk_setting
+            else:
+                def look_for_tsdk(x):
+                    x_appended = os.path.join(x, typescript_tsdk_setting)
+                    if is_tsdk_location_good(x_appended):
+                        return x_appended
+                    parent = os.path.dirname(x)
+                    if parent == x:
+                        return None  # We have reached the root
+                    return look_for_tsdk(parent)
+
+                # list(OrderedDict.fromkeys(x)) = deduped x, order preserved
+                folders = active_window.folders() + list(
+                    collections.OrderedDict.fromkeys(
+                        [
+                            os.path.dirname(x.file_name())
+                            for x in active_window.views()
+                            if x.file_name()  # It's None for unsaved files
+                        ]
+                    )
+                )
+                for folder in folders:
+                    x = look_for_tsdk(folder)
+                    if x != None:
+                        tsdk_location = x
+                        break
+
+        proc_file = os.path.join(tsdk_location, "tsserver.js")
+        global_vars._tsc_path = os.path.join(tsdk_location, "tsc.js")
+
+        log.warn("Path of tsserver.js: " + proc_file)
+        log.warn("Path of tsc.js: " + get_tsc_path())
 
         self.node_client = ServerClient(proc_file)
         self.worker_client = WorkerClient(proc_file)


### PR DESCRIPTION
Fix #538

This is flawed, of course, since the server used is never updated once initialized, so gotta restart ST when switching to/from a project with a custom `typescript_tsdk` set, but I can't afford to spend time on a refactor to accommodate this, and this is still much better than the status quo.