### PR TITLE
Add missing required arguments in call to `show_tooltip_popup()`

### DIFF
--- a/typescript/commands/quick_info.py
+++ b/typescript/commands/quick_info.py
@@ -141,9 +141,10 @@ class TypescriptQuickInfoDoc(TypeScriptBaseTextCommand):
         word_at_sel = self.view.classify(display_point)
         if hover_zone == sublime.HOVER_GUTTER:
             line_span = self.view.full_line(display_point)
+            errors = self.get_errors(line_span)
             error_html = self.get_error_text_html(line_span)
             if error_html:
-                self.show_tooltip_popup(display_point, error_html, None, None)
+                self.show_tooltip_popup(display_point, errors, error_html, None, None, None)
         elif word_at_sel & SUBLIME_WORD_MASK:
             cli.service.quick_info_full(self.view.file_name(), get_location_from_position(self.view, display_point), lambda response: self.handle_quick_info(response, display_point))
         else:


### PR DESCRIPTION
When hovering over the error indicator in the gutter, the following error is displayed in the console:
```
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 1082, in run_
    return self.run(edit, **args)
  File "~/Library/Application Support/Sublime Text 3/Packages/TypeScript/typescript/commands/quick_info.py", line 146, in run
    self.show_tooltip_popup(display_point, error_html, None, None)
TypeError: show_tooltip_popup() missing 2 required positional arguments: 'info_html' and 'doc'
```

The call to `show_tooltip_popup()` is missing several required positional arguments, this PR fixes the method call to include what is required.