### PR TITLE
Check for key in style before accessing.

### DIFF
--- a/typescript/libs/popup_formatter.py
+++ b/typescript/libs/popup_formatter.py
@@ -6,13 +6,13 @@ def format_css(style):
     """
     result = ""
 
-    if (style["foreground"]):
+    if ("foreground" in style and style["foreground"]):
         result += "color: {0};".format(style["foreground"])
 
-    if (style["bold"]):
+    if ("bold" in style and style["bold"]):
         result += "font-weight: bold;"
 
-    if (style["italic"]):
+    if ("italic" in style and style["italic"]):
         result += "font-style: italic;"
 
     return result


### PR DESCRIPTION
In the beta of Sublime Text v4 I get the following error in my console:

```
Exception in thread Thread-5:
Traceback (most recent call last):
  File "./python3.3/threading.py", line 901, in _bootstrap_inner
  File "./python3.3/threading.py", line 858, in run
  File "/Users/rgant/Library/Application Support/Sublime Text 3/Packages/TypeScript/typescript/libs/node_client.py", line 295, in __reader
    if NodeCommClient.read_msg(stream, msgq, asyncReq, proc, eventHandlers):
  File "/Users/rgant/Library/Application Support/Sublime Text 3/Packages/TypeScript/typescript/libs/node_client.py", line 194, in read_msg
    callback(data_dict)
  File "/Users/rgant/Library/Application Support/Sublime Text 3/Packages/TypeScript/typescript/commands/quick_info.py", line 148, in <lambda>
    cli.service.quick_info_full(self.view.file_name(), get_location_from_position(self.view, display_point), lambda response: self.handle_quick_info(response, display_point))
  File "/Users/rgant/Library/Application Support/Sublime Text 3/Packages/TypeScript/typescript/commands/quick_info.py", line 74, in handle_quick_info
    self.show_tooltip_popup(display_point, errors, error_html, info_text, info_str, doc_str)
  File "/Users/rgant/Library/Application Support/Sublime Text 3/Packages/TypeScript/typescript/commands/quick_info.py", line 80, in show_tooltip_popup
    theme_styles = get_theme_styles(self.view)
  File "/Users/rgant/Library/Application Support/Sublime Text 3/Packages/TypeScript/typescript/libs/popup_formatter.py", line 26, in get_theme_styles
    "type": format_css(view.style_for_scope("entity.name.type.class.ts")),
  File "/Users/rgant/Library/Application Support/Sublime Text 3/Packages/TypeScript/typescript/libs/popup_formatter.py", line 12, in format_css
    if (style["bold"]):
KeyError: 'bold'
```

I asked in the Sublime Discord about this and wbond responded:
> From looking at the implementation, the various keys for boolean values are only set if true. So I could consider this a documentation bug.
https://discordapp.com/channels/280102180189634562/280157083356233728/755131743266406451

This change is just a check that the key exists (adds support for v4) and is true (support for v3).