### PR TITLE
Fix popup styling for Sublime Text 4xxx (backwards compatible)

### DIFF
--- a/typescript/libs/popup_formatter.py
+++ b/typescript/libs/popup_formatter.py
@@ -6,13 +6,13 @@ def format_css(style):
     """
     result = ""
 
-    if (style["foreground"]):
+    if ("foreground" in style):
         result += "color: {0};".format(style["foreground"])
 
-    if (style["bold"]):
+    if ("bold" in style):
         result += "font-weight: bold;"
 
-    if (style["italic"]):
+    if ("italic" in style):
         result += "font-style: italic;"
 
     return result


### PR DESCRIPTION
Fixes #755 by accessing keys of the `style` object more safely.
Backwards compatible with any version of Sublime Text using Python 3+