### PR TITLE
Bypass the TSServer CRLF bug

### DIFF
--- a/typescript/libs/global_vars.py
+++ b/typescript/libs/global_vars.py
@@ -4,6 +4,8 @@ import logging
 import sublime
 from os.path import dirname
 
+IS_WINDOWS = sublime.platform() == "windows"
+
 # determine if the host is sublime text 2
 IS_ST2 = int(sublime.version()) < 3000
 

--- a/typescript/libs/node_client.py
+++ b/typescript/libs/node_client.py
@@ -185,6 +185,15 @@ class NodeCommClient(CommClient):
         if body_length > 0:
             data = stream.read(body_length)
             log.debug('Read body of length: {0}'.format(body_length))
+
+            # TypeScript adds a newline at the end of the response message and counts
+            # it as one character (LF) towards the content length. However, newlines
+            # are two characters on Windows (CR LF), so we need to take care of that.
+            # See issue: https://github.com/Microsoft/TypeScript/issues/3403
+            # The fix is based on: https://github.com/ycm-core/ycmd/pull/503
+            if global_vars.IS_WINDOWS and data.endswith(b'\r'):
+                data += stream.read(1)
+
             data_json = data.decode("utf-8")
 
             data_dict = json_helpers.decode(data_json)


### PR DESCRIPTION
Addresses https://github.com/microsoft/TypeScript-Sublime-Plugin/issues/765.

The plugin broke in the `master` branch after adding commit 64991b18ea7185cd8e1294b19f9cbfc8915a2283. After adding it, when `NodeCommClient` receives a message with an empty header, it tries to read an error from `stderr`.

TSServer doesn't handle line breaks correctly on Windows (https://github.com/Microsoft/TypeScript/issues/3403). Because of this the messages are parsed incorrectly, and the plugin gets into the very piece of code where it now tries to read an error. Before it used to just quit the function at that point and the parsing problem went unnoticed, but now the plugin is stuck trying to read `stderr`.

I found the information about the method of solving the problem here: https://github.com/ycm-core/ycmd/pull/503.

Hopefully, this will unblock the new release.